### PR TITLE
fix(Layout): the config now comes from nextjs method getConfig on the…

### DIFF
--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/authenticationLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/authenticationLayout.tsx
@@ -18,7 +18,6 @@ const AuthenticationLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Authentication'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/chatLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/chatLayout.tsx
@@ -11,7 +11,6 @@ const ChatLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Chat'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/databaseLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/databaseLayout.tsx
@@ -18,7 +18,6 @@ const DatabaseLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Database'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/emailsLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/emailsLayout.tsx
@@ -13,7 +13,6 @@ const EmailsLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Email'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/formsLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/formsLayout.tsx
@@ -12,7 +12,6 @@ const FormsLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Forms'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/notificationLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/notificationLayout.tsx
@@ -12,7 +12,6 @@ const NotificationLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Push Notifications'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/paymentsLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/paymentsLayout.tsx
@@ -21,7 +21,6 @@ const PaymentsLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Payments'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/securityLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/securityLayout.tsx
@@ -12,7 +12,6 @@ const SecurityLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Security'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/settingsLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/settingsLayout.tsx
@@ -18,7 +18,6 @@ const SettingsLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Settings'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/smsLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/smsLayout.tsx
@@ -12,7 +12,6 @@ const SMSLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'SMS'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/storageLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/storageLayout.tsx
@@ -12,7 +12,6 @@ const StorageLayout: React.FC = ({ children }) => {
 
   return (
     <StyledLayout
-      baseUrl={`${process.env.CONDUIT_URL}`}
       title={'Storage'}
       labels={labels}
       pathNames={pathNames}

--- a/apps/Conduit-UI/src/components/navigation/InnerLayouts/styledLayout.tsx
+++ b/apps/Conduit-UI/src/components/navigation/InnerLayouts/styledLayout.tsx
@@ -8,8 +8,9 @@ import Image from 'next/image';
 import { useAppSelector } from '../../../redux/store';
 import ScaleLoader from 'react-spinners/ScaleLoader';
 
+import { CONDUIT_API } from '../../../http/requestsConfig';
+
 interface Props {
-  baseUrl: string;
   title: string;
   labels: { name: string; id: string }[];
   pathNames: string[];
@@ -18,20 +19,12 @@ interface Props {
   children: any;
 }
 
-const StyledLayout: FC<Props> = ({
-  baseUrl,
-  title,
-  labels,
-  pathNames,
-  swagger,
-  icon,
-  children,
-}) => {
+const StyledLayout: FC<Props> = ({ title, labels, pathNames, swagger, icon, children }) => {
   const { loading } = useAppSelector((state) => state.appSlice);
 
   return (
     <SharedLayout
-      baseUrl={baseUrl}
+      baseUrl={CONDUIT_API}
       title={title}
       labels={labels}
       pathNames={pathNames}


### PR DESCRIPTION
This fixes #80 

Config now comes from NextJS's own method getConfig for the url of the Swagger/GraphQL buttons.


<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
