### PR TITLE
fix(Schema-editor): responsible thunk now has the option to not show …

### DIFF
--- a/apps/Conduit-UI/src/components/database/schemas/SchemaEditor.tsx
+++ b/apps/Conduit-UI/src/components/database/schemas/SchemaEditor.tsx
@@ -102,7 +102,7 @@ const SchemaEditor: FC<Props> = ({ introspection }) => {
   const [readOnly, setReadOnly] = useState(false);
 
   useEffect(() => {
-    if (!introspection && id) dispatch(asyncGetSchemaById({ id }));
+    if (!introspection && id) dispatch(asyncGetSchemaById({ id, noError: true }));
   }, [dispatch, introspection, id]);
 
   useEffect(() => {

--- a/apps/Conduit-UI/src/redux/slices/databaseSlice.ts
+++ b/apps/Conduit-UI/src/redux/slices/databaseSlice.ts
@@ -142,16 +142,15 @@ export const asyncGetSchemas = createAsyncThunk(
 
 export const asyncGetSchemaById = createAsyncThunk(
   'database/getSchemaById',
-  async (params: { id: string | string[] }, thunkAPI) => {
+  async (params: { id: string | string[]; noError?: boolean }, thunkAPI) => {
     thunkAPI.dispatch(setAppLoading(true));
     try {
       const { data } = await getSchemaByIdRequest(params.id);
-
       thunkAPI.dispatch(setAppLoading(false));
       return data;
     } catch (error) {
       thunkAPI.dispatch(setAppLoading(false));
-      thunkAPI.dispatch(enqueueErrorNotification(`${getErrorData(error)}`));
+      if (!params.noError) thunkAPI.dispatch(enqueueErrorNotification(`${getErrorData(error)}`));
       throw error;
     }
   }


### PR DESCRIPTION
…error msg when not needed

We no longer fetch every schema in order to make sure it exists or not (thankfully!).
So the responsible thunk resulting on an error was information we needed to make sure if the schema exists or not, so we now have the option to not show error msg on this particular thunk when not needed.



**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
