### PR TITLE
Client creation fix

### DIFF
--- a/apps/Conduit-UI/src/components/security/ClientsTab.tsx
+++ b/apps/Conduit-UI/src/components/security/ClientsTab.tsx
@@ -199,6 +199,7 @@ const ClientsTab: React.FC = () => {
       </Paper>
       <CreateSecurityClientDialog
         open={openDialog}
+        availableClients={availableClients}
         handleClose={handleClose}
         handleSuccess={handleSuccessfullClientCreation}
       />

--- a/apps/Conduit-UI/src/components/security/CreateSecurityClientDialog.tsx
+++ b/apps/Conduit-UI/src/components/security/CreateSecurityClientDialog.tsx
@@ -7,7 +7,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
 import { useAppDispatch } from '../../redux/store';
 import { Box } from '@mui/material';
-import ClientPlatformEnum, { ICreateClient } from '../../models/security/SecurityModels';
+import ClientPlatformEnum, { IClient, ICreateClient } from '../../models/security/SecurityModels';
 import { asyncGenerateNewClient, asyncGetAvailableClients } from '../../redux/slices/securitySlice';
 import { enqueueErrorNotification } from '../../utils/useNotifier';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -19,9 +19,15 @@ interface Props {
   open: boolean;
   handleClose: () => void;
   handleSuccess: () => void;
+  availableClients: IClient[];
 }
 
-const CreateSecurityClientDialog: React.FC<Props> = ({ open, handleClose, handleSuccess }) => {
+const CreateSecurityClientDialog: React.FC<Props> = ({
+  open,
+  handleClose,
+  handleSuccess,
+  availableClients,
+}) => {
   const dispatch = useAppDispatch();
 
   const methods = useForm<ICreateClient>({
@@ -34,17 +40,20 @@ const CreateSecurityClientDialog: React.FC<Props> = ({ open, handleClose, handle
     methods.reset({ platform: ClientPlatformEnum.WEB, domain: '*', alias: '', notes: '' });
   }, [methods, open]);
 
+  const foundAlias = (value: string) => availableClients.some((client) => client.alias === value);
+
   const onSubmit = (data: ICreateClient) => {
     if (data.platform === 'WEB' && (!data.domain || data.domain.length === 0)) {
       dispatch(enqueueErrorNotification(`Domain needs to be set for web clients`));
       return;
     }
+
     dispatch(
       asyncGenerateNewClient({
         platform: data.platform,
         domain: data.platform === 'WEB' ? data.domain : undefined,
-        notes: data.notes,
-        alias: data.alias,
+        notes: data.notes !== '' ? data.notes : undefined,
+        alias: data.alias !== '' ? data.alias : undefined,
       })
     );
 
@@ -78,7 +87,13 @@ const CreateSecurityClientDialog: React.FC<Props> = ({ open, handleClose, handle
                 label="Platform"
               />
               {isWeb && <FormInputText name={'domain'} label={'Domain'} />}
-              <FormInputText name={'alias'} label={'Alias'} />
+              <FormInputText
+                name={'alias'}
+                label={'Alias'}
+                rules={{
+                  validate: (value) => !foundAlias(value) || 'Alias already exists',
+                }}
+              />
               <FormInputText name={'notes'} label={'Notes'} />
             </Box>
             <Box width="100%" px={6} py={2}>

--- a/apps/Conduit-UI/src/components/security/CreateSecurityClientDialog.tsx
+++ b/apps/Conduit-UI/src/components/security/CreateSecurityClientDialog.tsx
@@ -91,7 +91,7 @@ const CreateSecurityClientDialog: React.FC<Props> = ({
                 name={'alias'}
                 label={'Alias'}
                 rules={{
-                  validate: (value) => !foundAlias(value) || 'Alias already exists',
+                  validate: (value) => !foundAlias(value) || value === '' || 'Alias already exists',
                 }}
               />
               <FormInputText name={'notes'} label={'Notes'} />


### PR DESCRIPTION
During security client creation we now check whether alias or notes are empty strings, so they are not being sent to the server.
 Also, a new security client now cannot be created without a unique alias if there is one.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
