### PR TITLE
fix(SchemaOverview): now showing compiled fields instead of fields

### DIFF
--- a/apps/Conduit-UI/src/components/database/schemas/SchemaOverview/SchemaOverview.tsx
+++ b/apps/Conduit-UI/src/components/database/schemas/SchemaOverview/SchemaOverview.tsx
@@ -115,7 +115,7 @@ export const SchemaOverview: FC<Props> = ({
     );
   };
 
-  const formattedFields = getSchemaFieldsWithExtra(schema.fields);
+  const formattedFields = getSchemaFieldsWithExtra(schema.compiledFields);
 
   const goToSchemaEndpoints = (name: string) => {
     router.push(`/database/custom?schema=${name}`, undefined, { shallow: true });
@@ -208,7 +208,7 @@ export const SchemaOverview: FC<Props> = ({
             ) : (
               <Box sx={{ borderRadius: 4, overflow: 'auto', height: '100%' }}>
                 <JsonEditorComponent
-                  placeholder={schema?.fields}
+                  placeholder={formattedFields}
                   viewOnly
                   height="100%"
                   width="100%"

--- a/apps/Conduit-UI/src/models/database/CmsModels.ts
+++ b/apps/Conduit-UI/src/models/database/CmsModels.ts
@@ -24,11 +24,19 @@ export interface Schema {
   };
   name: string;
   ownerModule: string;
-  extensions: any[];
+  extensions: Extension[];
   compiledFields: any;
   fields: any;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface Extension {
+  fields: any;
+  ownerModule: string;
+  createdAt: string;
+  updatedAt: string;
+  _id: string;
 }
 
 export interface ICrudOperations {


### PR DESCRIPTION
This PR includes the addition of showing all of the Schema Fields (extensions) on the Schema overview instead of just the default ones.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
