### PR TITLE
fix(database): broken relation doc links in document selection

### DIFF
--- a/apps/Conduit-UI/src/features/database/components/custom-endpoints/ListActions.tsx
+++ b/apps/Conduit-UI/src/features/database/components/custom-endpoints/ListActions.tsx
@@ -46,7 +46,7 @@ const ListActions: FC<Props> = ({ filters, schemasWithEndpoints, handleFilterCha
           variant="outlined"
           name="Search"
           size="small"
-          label="Find endpoint"
+          label="Find Endpoint"
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           InputProps={{
@@ -69,9 +69,7 @@ const ListActions: FC<Props> = ({ filters, schemasWithEndpoints, handleFilterCha
             onChange={(event) => {
               dispatch(setEndpointsOperation(event.target.value as number));
             }}>
-            <MenuItem value={-2}>
-              <em>All</em>
-            </MenuItem>
+            <MenuItem value={-2}>Any</MenuItem>
             <MenuItem value={0}>GET</MenuItem>
             <MenuItem value={1}>POST</MenuItem>
             <MenuItem value={2}>PUT</MenuItem>

--- a/apps/Conduit-UI/src/features/database/components/schemas/Introspection/IntrospectionLayout.tsx
+++ b/apps/Conduit-UI/src/features/database/components/schemas/Introspection/IntrospectionLayout.tsx
@@ -124,7 +124,7 @@ const IntrospectionLayout: FC = () => {
               />
             ) : (
               <Typography sx={{ marginTop: 20 }} variant={'h6'} textAlign={'center'}>
-                No selected Schema
+                No schema selected
               </Typography>
             )}
           </Box>

--- a/apps/Conduit-UI/src/features/database/components/schemas/Schemas.tsx
+++ b/apps/Conduit-UI/src/features/database/components/schemas/Schemas.tsx
@@ -231,7 +231,7 @@ const Schemas: FC = () => {
 
     return (
       <Typography sx={{ marginTop: 20 }} variant={'h6'} textAlign={'center'}>
-        No selected Schema
+        No schema selected
       </Typography>
     );
   };

--- a/apps/Conduit-UI/src/features/database/components/schemas/Schemas.tsx
+++ b/apps/Conduit-UI/src/features/database/components/schemas/Schemas.tsx
@@ -90,7 +90,10 @@ const Schemas: FC = () => {
   }, [schemaModel]);
 
   useEffect(() => {
-    if (schemaDocumentId) setSearch(`{"_id": "${schemaDocumentId}"}`);
+    if (schemaDocumentId) {
+      setSearch(`{"_id": "${schemaDocumentId}"}`);
+      setSelectedTab(1);
+    }
   }, [schemaDocumentId]);
 
   useEffect(() => {
@@ -205,7 +208,7 @@ const Schemas: FC = () => {
     }
   };
 
-  const handleTabChange = (event: any, newValue: any) => {
+  const handleTabChange = (event: any, newValue: number) => {
     setSelectedTab(newValue);
   };
 

--- a/apps/Conduit-UI/src/features/database/components/tree-components/tree-document-creation/RelationSelectInput.tsx
+++ b/apps/Conduit-UI/src/features/database/components/tree-components/tree-document-creation/RelationSelectInput.tsx
@@ -96,7 +96,7 @@ const RelationSelectInput: FC<RelationSelectInputProps> = ({
           <IconButton
             onClick={(e) => {
               window.open(
-                `/cms/schemadata?schemaModel=${schemaModel}&schemaDocumentId=${item._id}`
+                `/database/schemas?schemaModel=${schemaModel}&schemaDocumentId=${item._id}`
               );
               e.stopPropagation();
             }}


### PR DESCRIPTION
This PR fixes a broken link reproducible by clicking on the ~View button during relation schema doc selection (from doc selection dropdowns).
It also makes it so that supplying a schema document id query in the schemas page actually brings up the documents tab.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)