### PR TITLE
fix(SchemaEditor): default values such as _id, created, update now are pre-filled

### DIFF
--- a/apps/Conduit-UI/src/features/database/components/schemas/SchemaEditor.tsx
+++ b/apps/Conduit-UI/src/features/database/components/schemas/SchemaEditor.tsx
@@ -55,6 +55,12 @@ interface Props {
   introspection?: boolean;
 }
 
+const defaultFields = {
+  _id: 'ObjectId',
+  createdAt: 'Date',
+  updatedAt: 'Date',
+};
+
 const SchemaEditor: FC<Props> = ({ introspection }) => {
   const router = useRouter();
   const dispatch = useAppDispatch();
@@ -100,7 +106,12 @@ const SchemaEditor: FC<Props> = ({ introspection }) => {
   const [readOnly, setReadOnly] = useState(false);
 
   useEffect(() => {
-    if (!introspection && id && !isNew) dispatch(asyncGetSchemaById({ id, noError: true }));
+    if (!introspection && id && !isNew) {
+      dispatch(asyncGetSchemaById({ id, noError: true }));
+    } else if (isNew) {
+      const formattedFields = getSchemaFieldsWithExtra(defaultFields);
+      setEditableFields({ newTypeFields: formattedFields });
+    }
   }, [dispatch, introspection, id, isNew]);
 
   useEffect(() => {


### PR DESCRIPTION
In this PR the default values of a Schema (_id, createdAt, updatedAt) are present on the schema editor so that the user is aware that the fields will be created.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit-UI/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
