### PR TITLE
fix(database): CustomEndpoints lt,le,gt,ge field comparison operators not selectable for Date fields

### DIFF
--- a/apps/Conduit-UI/src/features/database/components/custom-endpoints/CustomQueryRow.tsx
+++ b/apps/Conduit-UI/src/features/database/components/custom-endpoints/CustomQueryRow.tsx
@@ -371,16 +371,24 @@ const CustomQueryRow: FC<Props> = ({
             <MenuItem aria-label="None" value="-1" />
             <MenuItem value={ConditionsEnum.EQUAL}>(==) equal to</MenuItem>
             <MenuItem value={ConditionsEnum.NEQUAL}>(!=) not equal to</MenuItem>
-            <MenuItem disabled={schemaType !== 'Number'} value={ConditionsEnum.GREATER}>
+            <MenuItem
+              disabled={!['Number', 'Date'].includes(schemaType)}
+              value={ConditionsEnum.GREATER}>
               {'(>) greater than'}
             </MenuItem>
-            <MenuItem disabled={schemaType !== 'Number'} value={ConditionsEnum.GREATER_EQ}>
-              {'(>=) greater that or equal to'}
+            <MenuItem
+              disabled={!['Number', 'Date'].includes(schemaType)}
+              value={ConditionsEnum.GREATER_EQ}>
+              {'(>=) greater than or equal to'}
             </MenuItem>
-            <MenuItem disabled={schemaType !== 'Number'} value={ConditionsEnum.LESS}>
+            <MenuItem
+              disabled={!['Number', 'Date'].includes(schemaType)}
+              value={ConditionsEnum.LESS}>
               {'(<) less than'}
             </MenuItem>
-            <MenuItem disabled={schemaType !== 'Number'} value={ConditionsEnum.LESS_EQ}>
+            <MenuItem
+              disabled={!['Number', 'Date'].includes(schemaType)}
+              value={ConditionsEnum.LESS_EQ}>
               {'(<=) less that or equal to'}
             </MenuItem>
             <MenuItem disabled={schemaType !== 'Array'} value={ConditionsEnum.EQUAL_SET}>


### PR DESCRIPTION
Fixes `LesserThan`, `LesserEqual`, `GreaterThan` and `GreaterEqual` field comparison operators not being selectable for `Date` fields.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)
