### PR TITLE
fix(database): schema editor _id, createdAt, updatedAt field constraints

### DIFF
--- a/apps/Conduit-UI/src/features/database/components/schemas/EditSchema/BuildTypesContent.tsx
+++ b/apps/Conduit-UI/src/features/database/components/schemas/EditSchema/BuildTypesContent.tsx
@@ -132,7 +132,10 @@ const BuildTypesContent: FC<Props> = ({
                             <CustomizedButton
                               onClick={() => handleDelete(index)}
                               disabled={disabled ? true : checkIfDisabled(item.name)}>
-                              <DeleteIcon color="error" sx={{ height: 25, width: 25 }} />
+                              <DeleteIcon
+                                color={disabled || checkIfDisabled(item.name) ? undefined : 'error'}
+                                sx={{ height: 25, width: 25 }}
+                              />
                             </CustomizedButton>
                             <CustomizedButton
                               onClick={() => handleDrawer(item, index)}

--- a/apps/Conduit-UI/src/utils/type-functions.js
+++ b/apps/Conduit-UI/src/utils/type-functions.js
@@ -118,7 +118,7 @@ export const getSchemaFieldsWithExtra = (schemaFields) => {
           type: 'Date',
           unique: false,
           select: true,
-          required: false,
+          required: true,
           value: field,
         });
       }
@@ -127,8 +127,9 @@ export const getSchemaFieldsWithExtra = (schemaFields) => {
           name: k,
           type: 'ObjectId',
           unique: true,
+          primaryKey: true,
           select: true,
-          required: false,
+          required: true,
           value: field,
         });
       }


### PR DESCRIPTION
Updates the schema editor so that non-editable fields' constraints are properly displayed.
Also recolors disabled fields' delete button (previously red despite being disabled).

Ideally we wouldn't be sending back `_id`, `createdAt` and `updatedAt` at all as the backend overrides these anyway, but the codebase is a mess, so yeah.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)