### PR TITLE
feat(database): owner filter and pagination for models list

### DIFF
--- a/src/app/(dashboard)/(modules)/database/models-new/page.tsx
+++ b/src/app/(dashboard)/(modules)/database/models-new/page.tsx
@@ -7,9 +7,45 @@ import { ModelsNewPage } from '@/components/database-new/models-page';
 
 export const dynamic = 'force-dynamic';
 
-export default async function ModelsNew() {
+const PAGE_SIZE = 10;
+
+type ModelsNewProps = {
+  searchParams: Promise<{
+    page?: string;
+    search?: string;
+    owner?: string;
+  }>;
+};
+
+function parsePage(raw: string | undefined): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return 1;
+  return Math.floor(n);
+}
+
+function parseOwners(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+export default async function ModelsNew(props: Readonly<ModelsNewProps>) {
+  const searchParams = await props.searchParams;
+
+  const page = parsePage(searchParams.page);
+  const search = searchParams.search?.trim() || '';
+  const owners = parseOwners(searchParams.owner);
+
   const [schemasData, modulesData, dbTypeRes] = await Promise.all([
-    getSchemas({ limit: 1000, enabled: true }),
+    getSchemas({
+      skip: (page - 1) * PAGE_SIZE,
+      limit: PAGE_SIZE,
+      enabled: true,
+      search: search || undefined,
+      owner: owners.length > 0 ? owners : undefined,
+    }),
     getSchemaOwnerModules({ sort: 'name' }),
     getDatabaseType(),
   ]);
@@ -20,6 +56,11 @@ export default async function ModelsNew() {
       modules={modulesData.modules}
       selectedModelId={null}
       databaseType={dbTypeRes.result}
+      count={schemasData.count}
+      page={page}
+      pageSize={PAGE_SIZE}
+      initialSearch={search}
+      initialOwners={owners}
     />
   );
 }

--- a/src/components/database-new/models-list-table.tsx
+++ b/src/components/database-new/models-list-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { DeclaredSchema } from '@/lib/models/database';
 import {
   Table,
@@ -14,6 +14,15 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -34,34 +43,113 @@ import { cn } from '@/lib/utils';
 type ModelsListTableProps = {
   schemas: DeclaredSchema[];
   modules: string[];
+  count: number;
+  page: number;
+  pageSize: number;
+  initialSearch: string;
+  initialOwners: string[];
   onCreateNew: () => void;
   onSelect: (modelId: string) => void;
   onDelete?: (modelId: string) => void;
 };
 
+const SEARCH_DEBOUNCE_MS = 300;
+
 export function ModelsListTable({
   schemas,
   modules,
+  count,
+  page,
+  pageSize,
+  initialSearch,
+  initialOwners,
   onCreateNew,
   onSelect,
   onDelete,
 }: ModelsListTableProps) {
-  const [search, setSearch] = React.useState('');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  const filteredSchemas = React.useMemo(() => {
-    if (!search) return schemas;
-    const searchLower = search.toLowerCase();
-    return schemas.filter(
-      schema =>
-        schema.name.toLowerCase().includes(searchLower) ||
-        schema.ownerModule.toLowerCase().includes(searchLower)
-    );
-  }, [schemas, search]);
+  const [searchInput, setSearchInput] = React.useState(initialSearch);
+
+  // Keep the input in sync if the URL changes from outside (e.g. Back button).
+  React.useEffect(() => {
+    setSearchInput(initialSearch);
+  }, [initialSearch]);
+
+  const setParams = React.useCallback(
+    (patch: Record<string, string | null>) => {
+      const next = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(patch)) {
+        if (value === null || value === '') {
+          next.delete(key);
+        } else {
+          next.set(key, value);
+        }
+      }
+      const qs = next.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [pathname, router, searchParams]
+  );
+
+  // Debounce search input -> URL.
+  React.useEffect(() => {
+    if (searchInput === initialSearch) return;
+    const handle = window.setTimeout(() => {
+      setParams({ search: searchInput || null, page: null });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [searchInput, initialSearch, setParams]);
+
+  const selectedOwners = React.useMemo(
+    () => new Set(initialOwners),
+    [initialOwners]
+  );
+
+  const toggleOwner = (owner: string) => {
+    const next = new Set(selectedOwners);
+    if (next.has(owner)) {
+      next.delete(owner);
+    } else {
+      next.add(owner);
+    }
+    const ordered = modules.filter(m => next.has(m));
+    setParams({
+      owner: ordered.length > 0 ? ordered.join(',') : null,
+      page: null,
+    });
+  };
+
+  const clearOwners = () => {
+    setParams({ owner: null, page: null });
+  };
+
+  const clearAllFilters = () => {
+    setSearchInput('');
+    setParams({ search: null, owner: null, page: null });
+  };
+
+  const totalPages = Math.max(1, Math.ceil(count / pageSize));
+  const hasFilters = initialSearch.length > 0 || selectedOwners.size > 0;
+  const showPagination = count > pageSize;
+
+  const goToPage = (target: number) => {
+    const clamped = Math.min(Math.max(target, 1), totalPages);
+    if (clamped === page) return;
+    setParams({ page: clamped === 1 ? null : String(clamped) });
+  };
 
   const getFieldCount = (schema: DeclaredSchema) => {
     const fields = schema.compiledFields || schema.fields || {};
     return Object.keys(fields).length;
   };
+
+  const pageNumbers = React.useMemo(
+    () => buildPageList(page, totalPages),
+    [page, totalPages]
+  );
 
   return (
     <div className="flex flex-col h-full">
@@ -72,7 +160,10 @@ export function ModelsListTable({
             <Database className="w-5 h-5 text-muted-foreground" />
             <h1 className="text-xl font-semibold">Database Models</h1>
           </div>
-          <Badge variant="secondary">{schemas.length} models</Badge>
+          <Badge variant="secondary">
+            {count} {count === 1 ? 'model' : 'models'}
+            {hasFilters ? ' (filtered)' : ''}
+          </Badge>
         </div>
         <Button onClick={onCreateNew} className="gap-2">
           <Plus className="w-4 h-4" />
@@ -86,32 +177,54 @@ export function ModelsListTable({
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
             placeholder="Search models..."
-            value={search}
-            onChange={e => setSearch(e.target.value)}
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
             className="pl-9"
           />
         </div>
       </div>
 
+      {/* Owner chips */}
+      {modules.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 px-6 py-3 border-b">
+          <span className="text-xs uppercase tracking-wide text-muted-foreground mr-1">
+            Owner
+          </span>
+          <OwnerChip
+            label="All"
+            isActive={selectedOwners.size === 0}
+            onClick={clearOwners}
+          />
+          {modules.map(owner => (
+            <OwnerChip
+              key={owner}
+              label={owner}
+              isActive={selectedOwners.has(owner)}
+              onClick={() => toggleOwner(owner)}
+            />
+          ))}
+        </div>
+      )}
+
       {/* Table */}
       <div className="flex-1 overflow-auto">
-        {filteredSchemas.length === 0 ? (
+        {schemas.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
               <FileJson className="w-8 h-8 text-muted-foreground" />
             </div>
-            {search ? (
+            {hasFilters ? (
               <>
                 <p className="text-lg font-medium">No models found</p>
                 <p className="text-sm text-muted-foreground mt-1">
-                  No models match &quot;{search}&quot;
+                  No models match the current filters
                 </p>
                 <Button
                   variant="link"
-                  onClick={() => setSearch('')}
+                  onClick={clearAllFilters}
                   className="mt-2"
                 >
-                  Clear search
+                  Clear filters
                 </Button>
               </>
             ) : (
@@ -138,7 +251,7 @@ export function ModelsListTable({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredSchemas.map(schema => (
+              {schemas.map(schema => (
                 <TableRow
                   key={schema._id}
                   className="cursor-pointer"
@@ -217,6 +330,108 @@ export function ModelsListTable({
           </Table>
         )}
       </div>
+
+      {/* Pagination */}
+      {showPagination && (
+        <div className="border-t px-6 py-3">
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  aria-disabled={page <= 1}
+                  className={cn(page <= 1 && 'pointer-events-none opacity-50')}
+                  onClick={e => {
+                    e.preventDefault();
+                    goToPage(page - 1);
+                  }}
+                />
+              </PaginationItem>
+              {pageNumbers.map((entry, idx) =>
+                entry === 'ellipsis' ? (
+                  <PaginationItem key={`ellipsis-${idx}`}>
+                    <PaginationEllipsis />
+                  </PaginationItem>
+                ) : (
+                  <PaginationItem key={entry}>
+                    <PaginationLink
+                      href="#"
+                      isActive={entry === page}
+                      onClick={e => {
+                        e.preventDefault();
+                        goToPage(entry);
+                      }}
+                    >
+                      {entry}
+                    </PaginationLink>
+                  </PaginationItem>
+                )
+              )}
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  aria-disabled={page >= totalPages}
+                  className={cn(
+                    page >= totalPages && 'pointer-events-none opacity-50'
+                  )}
+                  onClick={e => {
+                    e.preventDefault();
+                    goToPage(page + 1);
+                  }}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+      )}
     </div>
   );
+}
+
+type OwnerChipProps = {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+};
+
+function OwnerChip({ label, isActive, onClick }: OwnerChipProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={isActive}
+      onClick={onClick}
+      className="rounded-full focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      <Badge
+        variant={isActive ? 'default' : 'outline'}
+        className={cn(
+          'cursor-pointer font-normal capitalize',
+          !isActive && 'hover:bg-accent hover:text-accent-foreground'
+        )}
+      >
+        {label}
+      </Badge>
+    </button>
+  );
+}
+
+/**
+ * Build a compact pagination list with leading/trailing ellipses, matching the
+ * common 1 ... 4 5 6 ... 20 pattern. Always includes first and last page.
+ */
+function buildPageList(
+  current: number,
+  total: number
+): Array<number | 'ellipsis'> {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+  const pages: Array<number | 'ellipsis'> = [1];
+  const start = Math.max(2, current - 1);
+  const end = Math.min(total - 1, current + 1);
+  if (start > 2) pages.push('ellipsis');
+  for (let i = start; i <= end; i++) pages.push(i);
+  if (end < total - 1) pages.push('ellipsis');
+  pages.push(total);
+  return pages;
 }

--- a/src/components/database-new/models-page.tsx
+++ b/src/components/database-new/models-page.tsx
@@ -57,6 +57,16 @@ type ModelsNewPageProps = {
   initialTab?: ModelsNewTab;
   /** From GET /database/database-type; controls Mongo-only schema settings */
   databaseType?: string;
+  /** Total number of schemas matching current filters (server-side). List view only. */
+  count?: number;
+  /** Current 1-based page index for the list view. */
+  page?: number;
+  /** Page size used by the server fetch for the list view. */
+  pageSize?: number;
+  /** Initial search query parsed from the URL for the list view. */
+  initialSearch?: string;
+  /** Initial owner filter parsed from the URL for the list view. */
+  initialOwners?: string[];
 };
 
 export function ModelsNewPage({
@@ -68,6 +78,11 @@ export function ModelsNewPage({
   authResource,
   initialTab = 'schema',
   databaseType,
+  count,
+  page,
+  pageSize,
+  initialSearch,
+  initialOwners,
 }: ModelsNewPageProps) {
   const router = useRouter();
   const [activeTab, setActiveTab] = React.useState(() =>
@@ -119,6 +134,11 @@ export function ModelsNewPage({
         <ModelsListTable
           schemas={schemas}
           modules={modules}
+          count={count ?? schemas.length}
+          page={page ?? 1}
+          pageSize={pageSize ?? (schemas.length || 1)}
+          initialSearch={initialSearch ?? ''}
+          initialOwners={initialOwners ?? []}
           onCreateNew={handleCreateNew}
           onSelect={handleModelSelect}
         />


### PR DESCRIPTION
Add owner-chip filtering and server-side pagination (limit 10) to the Database Models list. Search, selected owners, and current page are all driven by URL search params (?search, ?owner, ?page), so filter state is shareable, survives reload, and works with browser Back/Forward.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/ConduitPlatform/Conduit-UI/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
