### PR TITLE
fix(ui): align communications admin API paths with v0.17 module

### DIFF
--- a/src/components/email/records/email-status.tsx
+++ b/src/components/email/records/email-status.tsx
@@ -1,66 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { RefreshCw } from 'lucide-react';
-import { fetchEmailStatus } from '@/lib/api/email';
 
 interface EmailStatusProps {
   emailId: string;
 }
 
-export function EmailStatus({ emailId }: Readonly<EmailStatusProps>) {
-  const [status, setStatus] = useState<any | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  const fetchStatus = async () => {
-    setLoading(true);
-    try {
-      const statusData = await fetchEmailStatus(emailId);
-      setStatus(statusData.statusInfo);
-    } catch (error) {
-      console.error('Failed to fetch email status:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchStatus();
-  }, [emailId]);
-
-  const getStatusBadge = () => {
-    if (!status) return <Badge variant="outline">Unknown</Badge>;
-
-    switch (status.status) {
-      case 'delivered':
-        return <Badge className="bg-green-500">Delivered</Badge>;
-      case 'failed':
-        return <Badge className="bg-red-500">Failed</Badge>;
-      case 'pending':
-        return (
-          <Badge variant="outline" className="bg-yellow-100 text-yellow-800">
-            Pending
-          </Badge>
-        );
-      default:
-        return <Badge variant="outline">Unknown</Badge>;
-    }
-  };
-
+export function EmailStatus(_props: Readonly<EmailStatusProps>) {
   return (
-    <div className="flex items-center space-x-2">
-      {getStatusBadge()}
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={fetchStatus}
-        disabled={loading}
-        className="h-8 w-8"
-      >
-        <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-      </Button>
-    </div>
+    <Badge
+      variant="outline"
+      title="Delivery status is not available via the admin API"
+    >
+      Unavailable
+    </Badge>
   );
 }

--- a/src/lib/api/email/index.ts
+++ b/src/lib/api/email/index.ts
@@ -71,9 +71,7 @@ export const createTemplate = async (data: {
 };
 
 export const deleteTemplates = async (ids: string[]) => {
-  return (await getApiClient())
-    .delete<string>('/email/templates', { params: { ids } })
-    .then(res => res.data);
+  await Promise.all(ids.map(id => deleteTemplate(id)));
 };
 
 export const deleteTemplate = async (id: string) => {
@@ -107,7 +105,7 @@ export const getExternalTemplates = async (args: {
     count: number;
   };
   return (await getApiClient())
-    .get<Response>('/email/externalTemplates', { params: args })
+    .get<Response>('/email/templates/external', { params: args })
     .then(res => res.data);
 };
 
@@ -117,17 +115,14 @@ export const syncTemplates = async () => {
     count: number;
   };
   return (await getApiClient())
-    .patch<Response>('/email/syncExternalTemplates')
+    .post<Response>('/email/templates/external/sync')
     .then(res => res.data);
 };
 
-export const uploadTemplate = async (id: string) => {
-  return (await getApiClient())
-    .post('/email/templates/upload', { _id: id })
-    .then(res => res.data)
-    .catch(err => {
-      throw new Error(err.response?.data.message ?? err.message);
-    });
+export const uploadTemplate = async (_id: string) => {
+  throw new Error(
+    'Template upload to the email provider is not available on the unified communications module'
+  );
 };
 
 export const sendEmail = async (data: EmailPayload) => {
@@ -136,16 +131,21 @@ export const sendEmail = async (data: EmailPayload) => {
 
 export const reSendEmail = async (emailRecordId: string) => {
   return (await getApiClient())
-    .post(`/email/resend`, { emailRecordId })
+    .post(`/email/resend`, { id: emailRecordId })
     .then(res => res.data);
 };
 
-export const fetchEmailStatus = async (messageId: string) => {
-  return (await getApiClient())
-    .get<{
-      statusInfo: any;
-    }>(`/email/status`, { params: { messageId } })
-    .then(res => res.data);
+const resolveEmailListSearch = (args: {
+  messageId?: string;
+  templateId?: string;
+  receiver?: string;
+  sender?: string;
+}): string | undefined => {
+  if (args.receiver) return args.receiver;
+  if (args.messageId?.match(/^[a-fA-F\d]{24}$/)) return args.messageId;
+  if (args.templateId?.match(/^[a-fA-F\d]{24}$/)) return args.templateId;
+  if (args.sender) return args.sender;
+  return args.messageId;
 };
 
 export const fetchRecords = async (args: {
@@ -162,10 +162,19 @@ export const fetchRecords = async (args: {
   sort?: string;
 }) => {
   type Response = {
-    records: EmailRecord[];
+    emailDocuments: EmailRecord[];
     count: number;
   };
-  return (await getApiClient())
-    .get<Response>('/email/record', { params: args })
-    .then(res => res.data);
+  const search = resolveEmailListSearch(args);
+  const res = await (
+    await getApiClient()
+  ).get<Response>('/email/emails', {
+    params: {
+      skip: args.skip,
+      limit: args.limit,
+      sort: args.sort,
+      ...(search ? { search } : {}),
+    },
+  });
+  return { records: res.data.emailDocuments, count: res.data.count };
 };

--- a/src/lib/api/notifications/index.ts
+++ b/src/lib/api/notifications/index.ts
@@ -12,6 +12,22 @@ import {
 
 type ConfigResponse = { config: NotificationSettings };
 
+type PushSendParams = {
+  userId: string;
+  title: string;
+  body?: string;
+  data?: Record<string, unknown>;
+  platform?: string;
+  doNotStore?: boolean;
+  isSilent?: boolean;
+};
+
+const postPushSend = async (params: PushSendParams) => {
+  const client = await getApiClient();
+  const res = await client.post('/push/send', params);
+  return res.data;
+};
+
 export const getNotificationSettings = async (): Promise<ConfigResponse> => {
   const res = await (
     await getApiClient()
@@ -37,6 +53,7 @@ export const patchNotificationSettings = async (
 
   return afterPatchServing(options);
 };
+
 export const getTokens = async (
   skip: number,
   limit: number,
@@ -48,7 +65,7 @@ export const getTokens = async (
 ): Promise<{ tokens: NotificationToken[]; count: number }> => {
   const res = await (
     await getApiClient()
-  ).get(`/pushNotifications/token`, {
+  ).get(`/push/tokens`, {
     params: {
       skip,
       limit,
@@ -64,50 +81,68 @@ export const getTokenById = async (
 ): Promise<NotificationToken> => {
   const res = await (
     await getApiClient()
-  ).get(`/pushNotifications/token/${id}`, {
+  ).get<{ tokenDocuments: NotificationToken }>(`/push/tokens/${id}`, {
     params: {
       populate,
     },
   });
-  return res.data;
+  return res.data.tokenDocuments;
 };
 
 export const sendNotifications = async (params: {
   userIds: string[];
   title: string;
   body?: string;
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
   isSilent?: boolean;
   platform?: string;
   doNotStore?: boolean;
-}): Promise<NotificationToken> => {
-  const res = await (
-    await getApiClient()
-  ).post(`/pushNotifications/sendToManyDevices`, {
-    ...params,
-  });
-  return res.data;
+}): Promise<void> => {
+  const { userIds, title, body, data, isSilent, platform, doNotStore } = params;
+  const results = await Promise.allSettled(
+    userIds.map(userId =>
+      postPushSend({
+        userId,
+        title,
+        body,
+        data,
+        isSilent,
+        platform,
+        doNotStore,
+      })
+    )
+  );
+  const failures = results.filter(r => r.status === 'rejected');
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to send to ${failures.length} of ${userIds.length} recipient(s)`
+    );
+  }
 };
 
 export const sendPushNotification = async (data: Record<string, unknown>) => {
-  const res = await (
-    await getApiClient()
-  ).post('/pushNotifications/send', data);
-  return res.data;
+  return postPushSend(data as PushSendParams);
 };
 
 export const sendManyPushNotifications = async (
-  data: Record<string, unknown>
+  notifications: PushSendParams[]
 ) => {
-  const res = await (
-    await getApiClient()
-  ).post('/pushNotifications/sendMany', data);
-  return res.data;
+  const results = await Promise.allSettled(
+    notifications.map(notification => postPushSend(notification))
+  );
+  const failures = results.filter(r => r.status === 'rejected');
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to send ${failures.length} of ${notifications.length} notification(s)`
+    );
+  }
 };
 
 export const getPushTokensForUser = async (userId: string) => {
   const res = await (
     await getApiClient()
-  ).get(`/pushNotifications/token/user/${userId}`);
-  return res.data;
+  ).get<{ tokens: NotificationToken[]; count: number }>(`/push/tokens`, {
+    params: { search: userId },
+  });
+  return { tokens: res.data.tokens };
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `ui-rewrite` branch

**Other information:**

Conduit-UI still called legacy standalone-module Admin API paths after the communications consolidation. Push token listing, test send, and several email operations returned 404 against v0.17+ backends.

- Push: `/pushNotifications/token` → `GET /push/tokens`; `/pushNotifications/token/:id` → `GET /push/tokens/:id` (unwrap `tokenDocuments`); send routes → `POST /push/send`; multi-recipient test send fans out per user via `POST /push/send`
- Email: `/email/externalTemplates` → `GET /email/templates/external`; sync `PATCH /email/syncExternalTemplates` → `POST /email/templates/external/sync`; records `GET /email/record` → `GET /email/emails` with `emailDocuments` → `records` mapping; resend body `{ emailRecordId }` → `{ id }`; bulk template delete loops `DELETE /email/templates/:id`
- Email delivery status badge shows "Unavailable" (no admin REST route for status polling)
- Template upload to provider throws a clear error (no admin upload route)

**Test plan**

- [ ] Push settings (`/push-notifications/settings`): load and save config
- [ ] Push tokens (`/push-notifications/tokens`): list, search, pagination — requests hit `/push/tokens`
- [ ] Push test send (`/push-notifications/test`): single and multiple recipients
- [ ] Email settings (`/email/settings`): load and save
- [ ] Email templates: list, create, edit, delete single and bulk selected
- [ ] External templates tab loads; sync triggers POST `/email/templates/external/sync`
- [ ] Email send and records list; resend from record detail
- [ ] Upload template action shows error toast instead of 404
- [ ] SMS settings and test send unchanged (`POST /sms/send`)
- [ ] `pnpm build` passes locally