### PR TITLE
feat(authentication)!: remove service account API client

### DIFF
--- a/src/lib/api/authentication/index.ts
+++ b/src/lib/api/authentication/index.ts
@@ -208,53 +208,6 @@ export const toggleUsersBlock = async (ids: string[], block: boolean) => {
   return res.data;
 };
 
-export type AuthService = {
-  _id: string;
-  name: string;
-  [key: string]: unknown;
-};
-
-export const getServices = async (params?: {
-  skip?: number;
-  limit?: number;
-  sort?: string;
-}) => {
-  const res = await (
-    await getApiClient()
-  ).get<{
-    services: AuthService[];
-    count: number;
-  }>('/authentication/services', { params });
-  return res.data;
-};
-
-export const createService = async (name: string) => {
-  const res = await (
-    await getApiClient()
-  ).post<{
-    name: string;
-    token: string;
-  }>('/authentication/services', { name });
-  return res.data;
-};
-
-export const deleteService = async (id: string) => {
-  const res = await (
-    await getApiClient()
-  ).delete<string>(`/authentication/services/${id}`);
-  return res.data;
-};
-
-export const renewServiceToken = async (serviceId: string) => {
-  const res = await (
-    await getApiClient()
-  ).get<{
-    name: string;
-    token: string;
-  }>(`/authentication/services/${serviceId}/token`);
-  return res.data;
-};
-
 export const removeTeamMembers = async (
   teamId: string,
   memberIds: string[]

--- a/src/lib/models/authentication/base.config.ts
+++ b/src/lib/models/authentication/base.config.ts
@@ -1,6 +1,5 @@
 export type BaseAuthenticationSettings = {
   active: boolean;
-  service: boolean;
   twoFa: {
     enabled: boolean;
     methods: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Refactor

**Does this PR introduce a breaking change?**

- [x] Yes

Removes client helpers for the deprecated authentication service-account admin routes. Platform operators should use the existing API Tokens UI (`/settings/api-tokens`) and Core `/api-tokens` endpoints instead.

**The PR fulfills these requirements:**

- [x] It's submitted to the `master` branch (target: `ui-rewrite`)

## Problem

The admin panel still exposed API client functions for authentication service accounts even though the backend is removing that credential model in favor of Core Admin API tokens.

## What changed

- Removed `getServices`, `createService`, `deleteService`, `renewServiceToken`, and `AuthService` from the authentication API client
- Removed `service` from `BaseAuthenticationSettings` config typing

API Tokens UI and `/api-tokens` client remain unchanged.

## Test plan

- [ ] Settings → API Tokens page loads and create/revoke still work
- [ ] No remaining imports reference removed service-account helpers
- [ ] Pair with Conduit `feat/remove-service-accounts` — service admin routes return 404

## Migration for operators

Use **Settings → API Tokens** (or Core `POST /api-tokens`) instead of any workflow that created authentication service accounts through the removed API.