### PR TITLE
feat(auth): add collapsible Apple multi-client OAuth settings

### DIFF
--- a/src/components/authentication/strategies/StrategySettings.tsx
+++ b/src/components/authentication/strategies/StrategySettings.tsx
@@ -67,7 +67,11 @@ export const StrategySettings: React.FC<StrategySettingsProps> = ({
       <DialogTrigger asChild>
         <Button variant="outline">Settings</Button>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent
+        className={
+          strategy.oauth ? 'max-h-[90vh] max-w-3xl overflow-y-auto' : undefined
+        }
+      >
         <DialogHeader>
           <DialogTitle className={'flex flex-row justify-between mt-5'}>
             {strategy.name} settings configuration
@@ -79,20 +83,22 @@ export const StrategySettings: React.FC<StrategySettingsProps> = ({
               Documentation
             </a>
           </DialogTitle>
-          <DialogDescription>
-            <hr className={'my-2'} />
-            {strategy.form ? (
-              <strategy.form
-                name={strategy.name}
-                data={strategy.data}
-                onSubmit={onSubmit}
-                onCancel={() => {
-                  setOpen(false);
-                }}
-              />
-            ) : (
-              'No settings available'
-            )}
+          <DialogDescription asChild>
+            <div>
+              <hr className={'my-2'} />
+              {strategy.form ? (
+                <strategy.form
+                  name={strategy.name}
+                  data={strategy.data}
+                  onSubmit={onSubmit}
+                  onCancel={() => {
+                    setOpen(false);
+                  }}
+                />
+              ) : (
+                'No settings available'
+              )}
+            </div>
           </DialogDescription>
         </DialogHeader>
       </DialogContent>

--- a/src/components/authentication/strategies/settingsConfig/oAuth/appleClientsSection.tsx
+++ b/src/components/authentication/strategies/settingsConfig/oAuth/appleClientsSection.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { InputField } from '@/components/ui/form-inputs/InputField';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
+import { SecretTextarea } from '@/components/ui/secret-textarea';
+import { ChevronDown, PlusIcon, Trash2Icon } from 'lucide-react';
+
+type CredentialFields = {
+  clientId?: string;
+  teamId?: string;
+  keyId?: string;
+  privateKey?: string;
+};
+
+function credentialLabel(fields: CredentialFields) {
+  const filled = [
+    fields.clientId,
+    fields.teamId,
+    fields.keyId,
+    fields.privateKey,
+  ]
+    .map(value => value?.trim())
+    .filter(Boolean).length;
+  if (filled === 0) return 'Not configured';
+  if (filled === 4) return 'Credentials complete';
+  return 'Incomplete';
+}
+
+function CredentialBadge({ fields }: { fields: CredentialFields }) {
+  const label = credentialLabel(fields);
+  return (
+    <Badge
+      variant={label === 'Credentials complete' ? 'secondary' : 'outline'}
+      className={
+        label === 'Not configured'
+          ? 'shrink-0 font-normal text-muted-foreground'
+          : 'shrink-0 font-normal'
+      }
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function fieldPath(prefix: string, name: string) {
+  return prefix ? `${prefix}${name}` : name;
+}
+
+function AppleClientFields({
+  prefix = '',
+  showIdentity,
+}: {
+  prefix?: string;
+  showIdentity?: boolean;
+}) {
+  const form = useFormContext();
+
+  return (
+    <div className="space-y-4 p-4">
+      {showIdentity && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <InputField
+            fieldName={fieldPath(prefix, 'id')}
+            label="Client ID (oauthClientId)"
+            description="Unique identifier passed during OAuth init"
+          />
+          <InputField
+            fieldName={fieldPath(prefix, 'name')}
+            label="Display name"
+            description="Admin label for this app"
+          />
+        </div>
+      )}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <InputField fieldName={fieldPath(prefix, 'teamId')} label="Team ID" />
+        <InputField
+          fieldName={fieldPath(prefix, 'clientId')}
+          label="Client ID"
+        />
+      </div>
+      <InputField
+        fieldName={fieldPath(prefix, 'keyId')}
+        label="Private key ID"
+      />
+      <FormField
+        control={form.control}
+        name={fieldPath(prefix, 'privateKey')}
+        render={({ field }) => (
+          <FormItem className="w-full space-y-1.5">
+            <FormLabel className="flex gap-2 pl-1 text-base font-medium text-text-body">
+              Private Key
+            </FormLabel>
+            <FormControl>
+              <SecretTextarea placeholder="" {...field} />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+      <InputField
+        fieldName={fieldPath(prefix, 'redirect_uri')}
+        label="Redirect URI"
+        description={
+          showIdentity ? 'Optional override for this client' : undefined
+        }
+      />
+    </div>
+  );
+}
+
+function AppleClientCollapsible({
+  title,
+  subtitle,
+  fields,
+  onRemove,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  fields: CredentialFields;
+  onRemove?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Collapsible className="mb-0 overflow-hidden rounded-md border">
+      <div className="flex items-center gap-2 bg-muted/30 p-3">
+        <CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+          <ChevronDown className="h-4 w-4 shrink-0 transition-transform ui-open:rotate-180" />
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <p className="truncate text-sm font-medium">{title}</p>
+            {subtitle ? (
+              <p className="truncate font-mono text-xs text-muted-foreground">
+                {subtitle}
+              </p>
+            ) : null}
+          </div>
+        </CollapsibleTrigger>
+        <CredentialBadge fields={fields} />
+        {onRemove ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            aria-label={`Remove ${title}`}
+            onClick={onRemove}
+          >
+            <Trash2Icon className="mr-1.5 h-4 w-4" />
+            Remove
+          </Button>
+        ) : null}
+      </div>
+      <CollapsibleContent>{children}</CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function AppleDefaultClientSection() {
+  const form = useFormContext();
+  const fields = {
+    clientId: form.watch('clientId'),
+    teamId: form.watch('teamId'),
+    keyId: form.watch('keyId'),
+    privateKey: form.watch('privateKey'),
+  };
+
+  return (
+    <section className="space-y-2">
+      <div className="space-y-1">
+        <h3 className="text-base font-semibold">Default client</h3>
+        <p className="text-sm text-muted-foreground">
+          Used when OAuth init does not pass{' '}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">
+            oauthClientId
+          </code>
+          .
+        </p>
+      </div>
+      <AppleClientCollapsible
+        title="Credentials"
+        subtitle="Fallback when oauthClientId is omitted"
+        fields={fields}
+      >
+        <AppleClientFields />
+      </AppleClientCollapsible>
+    </section>
+  );
+}
+
+const emptyAppleClient = {
+  id: '',
+  name: '',
+  clientId: '',
+  teamId: '',
+  keyId: '',
+  privateKey: '',
+  redirect_uri: '',
+};
+
+export function AppleAdditionalClientsSection() {
+  const form = useFormContext();
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'clients',
+  });
+
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h3 className="text-base font-semibold">App clients</h3>
+        <p className="text-sm text-muted-foreground">
+          Additional credential sets selected at login via{' '}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">
+            oauthClientId
+          </code>
+          .
+        </p>
+      </div>
+
+      {fields.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
+          No additional app clients configured.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {fields.map((field, index) => {
+            const prefix = `clients.${index}.`;
+            const name = form.watch(`${prefix}name`) ?? '';
+            const oauthClientId = form.watch(`${prefix}id`) ?? '';
+            const displayName = name.trim() || `Client ${index + 1}`;
+
+            return (
+              <AppleClientCollapsible
+                key={field.id}
+                title={displayName}
+                subtitle={
+                  oauthClientId.trim()
+                    ? `oauthClientId: ${oauthClientId}`
+                    : 'oauthClientId not set'
+                }
+                fields={{
+                  clientId: form.watch(`${prefix}clientId`),
+                  teamId: form.watch(`${prefix}teamId`),
+                  keyId: form.watch(`${prefix}keyId`),
+                  privateKey: form.watch(`${prefix}privateKey`),
+                }}
+                onRemove={() => remove(index)}
+              >
+                <AppleClientFields prefix={prefix} showIdentity />
+              </AppleClientCollapsible>
+            );
+          })}
+        </div>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full sm:w-auto"
+        onClick={() => append({ ...emptyAppleClient })}
+      >
+        <PlusIcon className="mr-1.5 h-4 w-4" />
+        Add app client
+      </Button>
+    </section>
+  );
+}

--- a/src/components/authentication/strategies/settingsConfig/oAuth/appleConfig.tsx
+++ b/src/components/authentication/strategies/settingsConfig/oAuth/appleConfig.tsx
@@ -2,74 +2,60 @@
 import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { rhfZodResolver } from '@/lib/zod-form';
-import { oauthDefaultConfig } from '@/components/authentication/strategies/settingsConfig/oAuth/oauthDefaultConfig';
+import { oauthProviderSettingsSchema } from '@/components/authentication/strategies/settingsConfig/oAuth/oauthDefaultConfig';
 import SwitchField from '@/components/ui/form-inputs/SwitchField';
-import { InputField } from '@/components/ui/form-inputs/InputField';
 import { Button } from '@/components/ui/button';
 import { StrategyFormProps } from '@/components/authentication/strategies/interface/StrategyFormProps.interface';
 import React from 'react';
+import { Form } from '@/components/ui/form';
 import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-} from '@/components/ui/form';
-import { SecretTextarea } from '@/components/ui/secret-textarea';
+  AppleAdditionalClientsSection,
+  AppleDefaultClientSection,
+} from '@/components/authentication/strategies/settingsConfig/oAuth/appleClientsSection';
+
+export const appleClientEntrySchema = z.object({
+  id: z.string().default(''),
+  name: z.string().default(''),
+  clientId: z.string().default(''),
+  teamId: z.string().default(''),
+  keyId: z.string().default(''),
+  privateKey: z.string().default(''),
+  redirect_uri: z.string().default(''),
+});
 
 type authStrategyFormType = z.infer<typeof authStrategySchema>;
-const authStrategySchema = oauthDefaultConfig.merge(
-  z.object({
-    privateKey: z.string().default(''),
-    teamId: z.string().default(''),
-    keyId: z.string().default(''),
-  })
-);
+const authStrategySchema = oauthProviderSettingsSchema.extend({
+  privateKey: z.string().default(''),
+  teamId: z.string().default(''),
+  keyId: z.string().default(''),
+  clients: z.array(appleClientEntrySchema).default([]),
+});
 
 export const AppleConfigForm: React.FC<
   StrategyFormProps<authStrategyFormType>
 > = ({ data, onSubmit, onCancel }) => {
   const form = useForm<authStrategyFormType>({
     resolver: rhfZodResolver(authStrategySchema),
-    defaultValues: data ? { ...data } : {},
+    defaultValues: { ...data, clients: data?.clients ?? [] },
   });
   const { isSubmitting } = form.formState;
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
-        <div className={'flex flex-col gap-1'}>
-          <div className={'flex flex-row gap-x-1'}>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
             <SwitchField fieldName={'enabled'} label={'Enabled'} />
             <SwitchField
               fieldName={'accountLinking'}
               label={'Account Linking'}
             />
           </div>
-          <div className={'flex flex-row gap-x-1'}>
-            <InputField fieldName={'teamId'} label={'Team ID'} />
-            <InputField fieldName={'clientId'} label={'Client ID'} />
-          </div>
 
-          <InputField fieldName={'keyId'} label={'Private key ID'} />
-          <FormField
-            control={form.control}
-            name="privateKey"
-            render={({ field }) => (
-              <FormItem className="w-full space-y-1.5">
-                <FormLabel className="flex gap-2 pl-1 text-base font-medium text-text-body">
-                  Private Key
-                </FormLabel>
-                <FormControl>
-                  <SecretTextarea placeholder="" {...field} />
-                </FormControl>
-              </FormItem>
-            )}
-          />
-          <div className={'flex flex-row gap-x-1 items-center'}>
-            <InputField fieldName={'redirect_uri'} label={'Redirect URI'} />
-          </div>
-          <div className={'flex flex-row gap-1 mt-4 justify-end'}>
+          <AppleDefaultClientSection />
+          <AppleAdditionalClientsSection />
+
+          <div className="flex flex-row justify-end gap-2 pt-2">
             <Button type={'reset'} disabled={isSubmitting} onClick={onCancel}>
               Cancel
             </Button>

--- a/src/components/authentication/strategies/settingsConfig/oAuth/microsoftConfig.tsx
+++ b/src/components/authentication/strategies/settingsConfig/oAuth/microsoftConfig.tsx
@@ -2,21 +2,17 @@
 import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { rhfZodResolver } from '@/lib/zod-form';
-import { oauthDefaultConfig } from '@/components/authentication/strategies/settingsConfig/oAuth/oauthDefaultConfig';
+import { oauthProviderSettingsSchema } from '@/components/authentication/strategies/settingsConfig/oAuth/oauthDefaultConfig';
 import SwitchField from '@/components/ui/form-inputs/SwitchField';
 import { InputField } from '@/components/ui/form-inputs/InputField';
 import { Button } from '@/components/ui/button';
 import { StrategyFormProps } from '@/components/authentication/strategies/interface/StrategyFormProps.interface';
 import React from 'react';
 import { Form } from '@/components/ui/form';
-import { TextAreaField } from '@/components/ui/form-inputs/TextAreaField';
-
 type authStrategyFormType = z.infer<typeof authStrategySchema>;
-const authStrategySchema = oauthDefaultConfig.merge(
-  z.object({
-    tenantId: z.string().default(''),
-  })
-);
+const authStrategySchema = oauthProviderSettingsSchema.extend({
+  tenantId: z.string().default(''),
+});
 
 export const MicrosoftConfigForm: React.FC<
   StrategyFormProps<authStrategyFormType>

--- a/src/components/authentication/strategies/settingsConfig/oAuth/oauthDefaultConfig.tsx
+++ b/src/components/authentication/strategies/settingsConfig/oAuth/oauthDefaultConfig.tsx
@@ -10,7 +10,7 @@ import SwitchField from '@/components/ui/form-inputs/SwitchField';
 import { InputField } from '@/components/ui/form-inputs/InputField';
 import { Button } from '@/components/ui/button';
 
-export const oauthDefaultConfig = z.object({
+export const oauthProviderSettingsSchema = z.object({
   enabled: z.boolean().default(false),
   clientId: z.string().default(''),
   clientSecret: z.string().default(''),
@@ -19,7 +19,7 @@ export const oauthDefaultConfig = z.object({
 });
 
 type authStrategyFormType = z.infer<typeof authStrategySchema>;
-const authStrategySchema = oauthDefaultConfig;
+const authStrategySchema = oauthProviderSettingsSchema;
 
 export const OauthDefaultConfigForm: React.FC<
   StrategyFormProps<authStrategyFormType>
@@ -29,18 +29,19 @@ export const OauthDefaultConfigForm: React.FC<
     defaultValues: data ? { ...data } : {},
   });
   const { isSubmitting } = form.formState;
+
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
-        <div className={'flex flex-col gap-1'}>
-          <div className={'flex flex-row gap-x-1'}>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
             <SwitchField fieldName={'enabled'} label={'Enabled'} />
             <SwitchField
               fieldName={'accountLinking'}
               label={'Account Linking'}
             />
           </div>
-          <div className={'flex flex-row gap-x-1'}>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <InputField fieldName={'clientId'} label={'Client ID'} />
             <InputField
               fieldName={'clientSecret'}
@@ -48,10 +49,8 @@ export const OauthDefaultConfigForm: React.FC<
               type="password"
             />
           </div>
-          <div className={'flex flex-row gap-x-1 items-center'}>
-            <InputField fieldName={'redirect_uri'} label={'Redirect URI'} />
-          </div>
-          <div className={'flex flex-row gap-1 mt-4 justify-end'}>
+          <InputField fieldName={'redirect_uri'} label={'Redirect URI'} />
+          <div className="flex flex-row justify-end gap-2 pt-2">
             <Button type={'reset'} disabled={isSubmitting} onClick={onCancel}>
               Cancel
             </Button>

--- a/src/lib/models/authentication/apple.config.ts
+++ b/src/lib/models/authentication/apple.config.ts
@@ -1,9 +1,20 @@
 import { Oauth2BaseConfig } from '@/lib/models/authentication/oauth2Base.config';
 
+export type AppleOAuthClientConfig = {
+  id: string;
+  name?: string;
+  clientId: string;
+  privateKey: string;
+  teamId: string;
+  keyId: string;
+  redirect_uri?: string;
+};
+
 export type AppleConfig = {
   apple: Oauth2BaseConfig & {
     privateKey: string;
     teamId: string;
     keyId: string;
+    clients?: AppleOAuthClientConfig[];
   };
 };


### PR DESCRIPTION
## Summary
- Add Apple-only multi-client OAuth settings UI with collapsed default and app client rows.
- Keep generic OAuth and Microsoft providers on the existing single-client form shape.
- Fix OAuth strategy settings dialog hydration by rendering form content inside `DialogDescription asChild`.

## Test plan
- [x] Targeted ESLint on changed OAuth files
- [x] `pnpm exec tsc --noEmit`
- [ ] Open `/authentication/strategies` and verify Apple settings are compact by default
- [ ] Expand default and additional Apple client rows and save credentials
- [ ] Confirm GitHub/Microsoft settings do not show multi-client controls