### PR TITLE
fix(communications): load templates client-side with graceful API failures

### DIFF
--- a/src/app/(dashboard)/(modules)/communications/templates/page.tsx
+++ b/src/app/(dashboard)/(modules)/communications/templates/page.tsx
@@ -1,13 +1,9 @@
-import { getCommunicationTemplates } from '@/lib/api/communications/templates';
-import { getExternalTemplates, getTemplates } from '@/lib/api/email';
 import { CommunicationTemplatesDashboard } from '@/components/communications/templates/dashboard';
 import {
   PageDescription,
   PageHeader,
   PageTitle,
 } from '@/components/ui/page-header';
-
-const TEMPLATE_LIST_LIMIT = 500;
 
 type CommunicationTemplatesParams = {
   searchParams: Promise<{
@@ -23,24 +19,6 @@ export default async function CommunicationTemplatesPage(
   props: Readonly<CommunicationTemplatesParams>
 ) {
   const searchParams = await props.searchParams;
-
-  const fetchArgs = {
-    skip: searchParams.pageIndex ? searchParams.pageIndex * 10 : 0,
-    limit: TEMPLATE_LIST_LIMIT,
-    sort: searchParams.sort,
-    search: searchParams.search,
-  };
-
-  const [communicationTemplates, emailTemplates, externalTemplates] =
-    await Promise.all([
-      getCommunicationTemplates(fetchArgs),
-      getTemplates(fetchArgs),
-      getExternalTemplates({
-        limit: TEMPLATE_LIST_LIMIT,
-        sortByName: true,
-      }).catch(() => null),
-    ]);
-
   const emailTemplateId = searchParams.email ?? searchParams.legacy;
 
   return (
@@ -54,12 +32,7 @@ export default async function CommunicationTemplatesPage(
         </div>
       </PageHeader>
 
-      <CommunicationTemplatesDashboard
-        communicationTemplates={communicationTemplates}
-        emailTemplates={emailTemplates}
-        externalTemplates={externalTemplates}
-        emailTemplateId={emailTemplateId}
-      />
+      <CommunicationTemplatesDashboard emailTemplateId={emailTemplateId} />
     </div>
   );
 }

--- a/src/app/(dashboard)/(modules)/communications/test/page.tsx
+++ b/src/app/(dashboard)/(modules)/communications/test/page.tsx
@@ -1,4 +1,3 @@
-import { getTemplates } from '@/lib/api/email';
 import { getTokenById } from '@/lib/api/notifications';
 import { CommunicationsTestTabs } from '@/components/communications/test/communications-test-tabs';
 import {
@@ -26,12 +25,9 @@ export default async function CommunicationsTestPage(
   const searchParams = await props.searchParams;
   const tab = parseTab(searchParams.tab);
 
-  const [templates, token] = await Promise.all([
-    getTemplates({}),
-    !isEmpty(searchParams.token)
-      ? getTokenById(searchParams.token ?? '', 'user')
-      : Promise.resolve(undefined),
-  ]);
+  const token = !isEmpty(searchParams.token)
+    ? await getTokenById(searchParams.token ?? '', 'user')
+    : undefined;
 
   return (
     <div className="space-y-6">
@@ -44,11 +40,7 @@ export default async function CommunicationsTestPage(
         </div>
       </PageHeader>
 
-      <CommunicationsTestTabs
-        initialTab={tab}
-        templates={templates}
-        token={token}
-      />
+      <CommunicationsTestTabs initialTab={tab} token={token} />
     </div>
   );
 }

--- a/src/app/(dashboard)/(modules)/database/models/[modelId]/page.tsx
+++ b/src/app/(dashboard)/(modules)/database/models/[modelId]/page.tsx
@@ -24,6 +24,7 @@ type PageProps = {
     limit?: string;
     tab?: string;
     created?: string;
+    list?: string;
   }>;
 };
 
@@ -81,6 +82,7 @@ export default async function ModelDetailPage(props: Readonly<PageProps>) {
       initialTab={initialTab}
       databaseType={dbTypeRes.result}
       created={searchParams?.created === '1'}
+      listQuery={searchParams?.list}
     />
   );
 }

--- a/src/app/(dashboard)/(modules)/error.tsx
+++ b/src/app/(dashboard)/(modules)/error.tsx
@@ -15,10 +15,17 @@ export default function ModuleError({
   const pathname = usePathname();
   const moduleSlug = pathname.split('/')[1];
 
+  const message = [
+    error.message,
+    error.digest ? `Error ID: ${error.digest}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
   return (
     <ErrorCard
       title="Module Error"
-      message={error.message}
+      message={message}
       onRetry={reset}
       actions={
         moduleSlug ? (

--- a/src/components/communications/templates/columns.tsx
+++ b/src/components/communications/templates/columns.tsx
@@ -27,7 +27,7 @@ import { ExternalTemplate } from '@/lib/models/email';
 import { EmailTemplatePreview } from './email-template-preview';
 
 type TemplateRowColumnsOptions = {
-  onAddChannels: (emailTemplateId: string) => void;
+  onAddChannels?: (emailTemplateId: string) => void;
 };
 
 function ExternalTemplateViewDialog({
@@ -109,7 +109,7 @@ function ActionsCell({
   onAddChannels,
 }: {
   row: TemplateRow;
-  onAddChannels: (emailTemplateId: string) => void;
+  onAddChannels?: (emailTemplateId: string) => void;
 }) {
   const router = useRouter();
   const { toast } = useToast();
@@ -141,14 +141,16 @@ function ActionsCell({
     case 'email':
       return (
         <div className="flex items-center justify-end gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => onAddChannels(row.template._id)}
-          >
-            Add channels
-          </Button>
+          {onAddChannels && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => onAddChannels(row.template._id)}
+            >
+              Add channels
+            </Button>
+          )}
           <Link
             href={`/communications/templates/email/${row.template._id}`}
             aria-label={`View ${row.template.name}`}

--- a/src/components/communications/templates/dashboard.tsx
+++ b/src/components/communications/templates/dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { AlertCircle, Info } from 'lucide-react';
 import { CommunicationTemplatesTable } from './data-table';
 import { SearchInput } from '@/components/helpers/search';
 import { CreateCommunicationTemplateSheet } from './create-template-sheet';
@@ -9,8 +10,19 @@ import { BulkAddChannelsButton } from './bulk-add-channels-button';
 import { AddChannelsDialog } from './add-channels-dialog';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/lib/hooks/use-toast';
-import { syncTemplates } from '@/lib/api/email';
+import { getCommunicationTemplates } from '@/lib/api/communications/templates';
+import {
+  getExternalTemplates,
+  getTemplates,
+  syncTemplates,
+} from '@/lib/api/email';
+import {
+  formatCommunicationsApiError,
+  formatEmailTemplatesApiError,
+} from '@/lib/logic/api-error';
 import { RefreshCw } from 'lucide-react';
 import { isNil } from 'lodash';
 import { mergeTemplateRows } from '@/lib/logic/merge-template-rows';
@@ -22,6 +34,8 @@ import {
 } from '@/lib/models/communications/template-row';
 import { CommunicationTemplate } from '@/lib/models/communications/templates';
 import { EmailTemplate, ExternalTemplate } from '@/lib/models/email';
+
+const TEMPLATE_LIST_LIMIT = 500;
 
 type CommunicationTemplatesResponse = {
   templateDocuments: CommunicationTemplate[];
@@ -38,15 +52,19 @@ type ExternalTemplatesResponse = {
   count: number;
 };
 
+const EMPTY_UNIFIED: CommunicationTemplatesResponse = {
+  templateDocuments: [],
+  count: 0,
+};
+
+const EMPTY_EMAIL: EmailTemplatesResponse = {
+  templateDocuments: [],
+  count: 0,
+};
+
 export function CommunicationTemplatesDashboard({
-  communicationTemplates,
-  emailTemplates,
-  externalTemplates,
   emailTemplateId,
 }: {
-  communicationTemplates: CommunicationTemplatesResponse;
-  emailTemplates: EmailTemplatesResponse;
-  externalTemplates: ExternalTemplatesResponse | null;
   emailTemplateId?: string;
 }) {
   const router = useRouter();
@@ -54,12 +72,72 @@ export function CommunicationTemplatesDashboard({
   const searchParams = useSearchParams();
   const { toast } = useToast();
 
+  const [communicationTemplates, setCommunicationTemplates] =
+    useState<CommunicationTemplatesResponse>(EMPTY_UNIFIED);
+  const [emailTemplates, setEmailTemplates] =
+    useState<EmailTemplatesResponse>(EMPTY_EMAIL);
+  const [externalTemplates, setExternalTemplates] =
+    useState<ExternalTemplatesResponse | null>(null);
+  const [unifiedApiAvailable, setUnifiedApiAvailable] = useState(true);
+  const [emailTemplatesError, setEmailTemplatesError] = useState<string | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(true);
+
   const [sourceFilter, setSourceFilter] = useState<TemplateFilter>('all');
   const [channelFilter, setChannelFilter] = useState<ChannelFilter>('all');
   const [addChannelsDialogId, setAddChannelsDialogId] = useState<string | null>(
     null
   );
   const [addChannelsDialogOpen, setAddChannelsDialogOpen] = useState(false);
+
+  const pageIndex = Number.parseInt(searchParams.get('pageIndex') ?? '0', 10);
+  const sort = searchParams.get('sort') ?? undefined;
+  const search = searchParams.get('search') ?? undefined;
+
+  const loadTemplates = useCallback(async () => {
+    setIsLoading(true);
+    setEmailTemplatesError(null);
+
+    const fetchArgs = {
+      skip: Number.isNaN(pageIndex) ? 0 : pageIndex * 10,
+      limit: TEMPLATE_LIST_LIMIT,
+      sort,
+      search,
+    };
+
+    const [unifiedResult, emailResult, externalResult] = await Promise.all([
+      getCommunicationTemplates(fetchArgs).catch(err => ({ err })),
+      getTemplates(fetchArgs).catch(err => ({ err })),
+      getExternalTemplates({
+        limit: TEMPLATE_LIST_LIMIT,
+        sortByName: true,
+      }).catch(() => null),
+    ]);
+
+    if ('err' in unifiedResult) {
+      setUnifiedApiAvailable(false);
+      setCommunicationTemplates(EMPTY_UNIFIED);
+    } else {
+      setUnifiedApiAvailable(true);
+      setCommunicationTemplates(unifiedResult);
+    }
+
+    if ('err' in emailResult) {
+      setEmailTemplates(EMPTY_EMAIL);
+      setEmailTemplatesError(formatEmailTemplatesApiError(emailResult.err));
+    } else {
+      setEmailTemplates(emailResult);
+      setEmailTemplatesError(null);
+    }
+
+    setExternalTemplates(externalResult);
+    setIsLoading(false);
+  }, [pageIndex, search, sort]);
+
+  useEffect(() => {
+    void loadTemplates();
+  }, [loadTemplates]);
 
   const mergedRows = useMemo(
     () =>
@@ -127,18 +205,50 @@ export function CommunicationTemplatesDashboard({
           title: 'Communications',
           description: 'External templates synced successfully',
         });
-        router.refresh();
+        void loadTemplates();
       })
       .catch(err =>
         toast({
           title: 'Communications',
-          description: err.message,
+          description: formatCommunicationsApiError(err),
         })
       );
   };
 
+  if (!isLoading && emailTemplatesError) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>Could not load email templates</AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p>{emailTemplatesError}</p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={loadTemplates}
+          >
+            Try again
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
   return (
     <div className="space-y-6">
+      {!unifiedApiAvailable && (
+        <Alert variant="warning">
+          <Info className="h-4 w-4" />
+          <AlertTitle>Unified templates unavailable</AlertTitle>
+          <AlertDescription>
+            Multi-channel unified templates require a Conduit build with
+            CommunicationTemplate CRUD. Email and external templates are still
+            available below.
+          </AlertDescription>
+        </Alert>
+      )}
+
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <Tabs
           value={sourceFilter}
@@ -167,7 +277,9 @@ export function CommunicationTemplatesDashboard({
 
       <div className="flex flex-wrap items-center gap-3">
         <SearchInput />
-        <BulkAddChannelsButton emailTemplateCount={emailTemplateCount} />
+        {unifiedApiAvailable && (
+          <BulkAddChannelsButton emailTemplateCount={emailTemplateCount} />
+        )}
         {!isNil(externalTemplates) && (
           <Button
             variant="secondary"
@@ -178,19 +290,32 @@ export function CommunicationTemplatesDashboard({
             Sync external
           </Button>
         )}
-        <CreateCommunicationTemplateSheet />
+        {unifiedApiAvailable && <CreateCommunicationTemplateSheet />}
       </div>
 
-      <CommunicationTemplatesTable
-        rows={displayedRows}
-        onAddChannels={openAddChannelsDialog}
-      />
-
-      {sourceFilter === 'external' && isNil(externalTemplates) && (
-        <p className="text-center text-sm text-muted-foreground">
-          External templates are not available for this email provider.
-        </p>
+      {isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ) : (
+        <CommunicationTemplatesTable
+          rows={displayedRows}
+          onAddChannels={
+            unifiedApiAvailable ? openAddChannelsDialog : undefined
+          }
+        />
       )}
+
+      {sourceFilter === 'external' &&
+        isNil(externalTemplates) &&
+        !isLoading && (
+          <p className="text-center text-sm text-muted-foreground">
+            External templates are not available for this email provider.
+          </p>
+        )}
 
       <AddChannelsDialog
         emailTemplateId={addChannelsDialogId}

--- a/src/components/communications/templates/data-table.tsx
+++ b/src/components/communications/templates/data-table.tsx
@@ -6,7 +6,7 @@ import { useTemplateRowColumns } from './columns';
 
 type CommunicationTemplatesTableProps = {
   rows: TemplateRow[];
-  onAddChannels: (emailTemplateId: string) => void;
+  onAddChannels?: (emailTemplateId: string) => void;
 };
 
 export function CommunicationTemplatesTable({

--- a/src/components/communications/test/communications-test-tabs.tsx
+++ b/src/components/communications/test/communications-test-tabs.tsx
@@ -1,11 +1,16 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { AlertCircle } from 'lucide-react';
 import { SendEmailForm } from '@/components/email/send/form';
 import { TestSendSmsForm } from '@/components/sms/smsTest/testSendSmsForm';
 import { TestSendForm } from '@/components/notifications/testSend/testSendForm';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { EmailTemplate } from '@/lib/models/email';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getTemplates } from '@/lib/api/email';
+import { formatEmailTemplatesApiError } from '@/lib/logic/api-error';
 import { NotificationToken } from '@/lib/models/notification/NotificationToken';
 
 const TEST_TABS = ['email', 'sms', 'push'] as const;
@@ -16,25 +21,55 @@ function parseTestTab(tab: string | undefined): TestTab {
   return 'email';
 }
 
-type EmailTemplates = {
-  templateDocuments: EmailTemplate[];
-  count: number;
-};
-
 type CommunicationsTestTabsProps = {
   initialTab: TestTab;
-  templates: EmailTemplates;
   token?: NotificationToken;
 };
 
 export function CommunicationsTestTabs({
   initialTab,
-  templates,
   token,
 }: CommunicationsTestTabsProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const activeTab = initialTab;
+
+  const [templates, setTemplates] = useState<Awaited<
+    ReturnType<typeof getTemplates>
+  > | null>(null);
+  const [templatesError, setTemplatesError] = useState<string | null>(null);
+  const [isLoadingTemplates, setIsLoadingTemplates] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadTemplates = async () => {
+      setIsLoadingTemplates(true);
+      setTemplatesError(null);
+
+      try {
+        const data = await getTemplates({});
+        if (!cancelled) {
+          setTemplates(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setTemplates(null);
+          setTemplatesError(formatEmailTemplatesApiError(err));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingTemplates(false);
+        }
+      }
+    };
+
+    void loadTemplates();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleTabChange = (value: string) => {
     const tab = parseTestTab(value);
@@ -60,7 +95,23 @@ export function CommunicationsTestTabs({
       </TabsList>
 
       <TabsContent value="email" className="mt-6">
-        <SendEmailForm templates={templates} embedded />
+        {isLoadingTemplates && (
+          <div className="space-y-4">
+            <Skeleton className="h-10 w-full max-w-md" />
+            <Skeleton className="h-10 w-full max-w-md" />
+            <Skeleton className="h-32 w-full" />
+          </div>
+        )}
+        {!isLoadingTemplates && templatesError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Could not load email templates</AlertTitle>
+            <AlertDescription>{templatesError}</AlertDescription>
+          </Alert>
+        )}
+        {!isLoadingTemplates && templates && (
+          <SendEmailForm templates={templates} embedded />
+        )}
       </TabsContent>
 
       <TabsContent value="sms" className="mt-6">

--- a/src/components/database/models/models-list-table.tsx
+++ b/src/components/database/models/models-list-table.tsx
@@ -49,7 +49,7 @@ type ModelsListTableProps = {
   initialSearch: string;
   initialOwners: string[];
   onCreateNew: () => void;
-  onSelect: (modelId: string) => void;
+  onSelect: (modelId: string, listQuery?: string) => void;
   onOpenSchemaTransfer: () => void;
   onDelete?: (modelId: string) => void;
 };
@@ -267,7 +267,10 @@ export function ModelsListTable({
                 <TableRow
                   key={schema._id}
                   className="cursor-pointer"
-                  onClick={() => onSelect(schema._id)}
+                  onClick={() => {
+                    const listQuery = searchParams.toString();
+                    onSelect(schema._id, listQuery || undefined);
+                  }}
                 >
                   <TableCell>
                     <div className="flex items-center gap-3">
@@ -315,7 +318,8 @@ export function ModelsListTable({
                         <DropdownMenuItem
                           onClick={e => {
                             e.stopPropagation();
-                            onSelect(schema._id);
+                            const listQuery = searchParams.toString();
+                            onSelect(schema._id, listQuery || undefined);
                           }}
                         >
                           <ExternalLink className="w-4 h-4 mr-2" />

--- a/src/components/database/models/models-page.tsx
+++ b/src/components/database/models/models-page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { DeclaredSchema } from '@/lib/models/database';
 import { ResourceDefinition } from '@/lib/models/authorization';
 import { deleteSchema, exportSchemas, importSchemas } from '@/lib/api/database';
@@ -36,6 +36,11 @@ import {
 import { Button } from '@/components/ui/button';
 import ExportImportDialog from '@/components/ui/export-import-dialog';
 import { toast } from '@/lib/hooks/use-toast';
+import {
+  buildModelDetailHref,
+  buildModelDetailTabHref,
+  buildModelsListHref,
+} from '@/lib/database/models-navigation';
 
 export type ModelsTab =
   | 'schema'
@@ -90,6 +95,8 @@ type ModelsPageProps = {
   initialOwners?: string[];
   /** True immediately after quick-create redirects into the editor. */
   created?: boolean;
+  /** Encoded list filters from the models list (owner, page, search). */
+  listQuery?: string;
 };
 
 export function ModelsPage({
@@ -107,8 +114,10 @@ export function ModelsPage({
   initialSearch,
   initialOwners,
   created = false,
+  listQuery,
 }: ModelsPageProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [activeTab, setActiveTab] = React.useState(() =>
     normalizeTab(initialTab)
   );
@@ -175,9 +184,10 @@ export function ModelsPage({
     };
   }, [hasDirtyChanges]);
 
-  const handleModelSelect = (modelId: string) => {
+  const handleModelSelect = (modelId: string, fromListQuery?: string) => {
+    const query = fromListQuery ?? listQuery;
     requestNavigation(() => {
-      router.push(`/database/models/${modelId}`);
+      router.push(buildModelDetailHref(modelId, query));
     });
   };
 
@@ -188,9 +198,10 @@ export function ModelsPage({
     requestNavigation(() => {
       setActiveTab(nextTab);
       if (selectedModelId) {
-        router.push(`/database/models/${selectedModelId}?tab=${nextTab}`, {
-          scroll: false,
-        });
+        router.push(
+          buildModelDetailTabHref(selectedModelId, nextTab, searchParams),
+          { scroll: false }
+        );
       }
     });
   };
@@ -284,7 +295,7 @@ export function ModelsPage({
 
   const handleBackToList = () => {
     requestNavigation(() => {
-      router.push('/database/models');
+      router.push(buildModelsListHref(listQuery));
     });
   };
 

--- a/src/lib/api/communications/templates.ts
+++ b/src/lib/api/communications/templates.ts
@@ -6,12 +6,16 @@ import {
   CommunicationTemplatePayload,
 } from '@/lib/models/communications/templates';
 import { MigrationResponse } from '@/lib/models/communications/template-row';
-import { formatCommunicationsApiError } from '@/lib/logic/api-error';
+import {
+  formatCommunicationsApiError,
+  isNextNavigationError,
+} from '@/lib/logic/api-error';
 
 async function withCommunicationsError<T>(fn: () => Promise<T>): Promise<T> {
   try {
     return await fn();
   } catch (err) {
+    if (isNextNavigationError(err)) throw err;
     throw new Error(formatCommunicationsApiError(err));
   }
 }

--- a/src/lib/database/models-navigation.ts
+++ b/src/lib/database/models-navigation.ts
@@ -1,0 +1,31 @@
+const MODELS_LIST_PATH = '/database/models';
+
+/** Build href for a model detail page, optionally preserving list filter state. */
+export function buildModelDetailHref(
+  modelId: string,
+  listQuery?: string
+): string {
+  const base = `${MODELS_LIST_PATH}/${modelId}`;
+  if (!listQuery) return base;
+  return `${base}?list=${encodeURIComponent(listQuery)}`;
+}
+
+/** Build href for the models list, optionally restoring filter/pagination state. */
+export function buildModelsListHref(listQuery?: string): string {
+  if (!listQuery) return MODELS_LIST_PATH;
+  return `${MODELS_LIST_PATH}?${listQuery}`;
+}
+
+/** Merge a tab change into the current detail-page search params. */
+export function buildModelDetailTabHref(
+  modelId: string,
+  tab: string,
+  currentParams: URLSearchParams
+): string {
+  const next = new URLSearchParams(currentParams.toString());
+  next.set('tab', tab);
+  const qs = next.toString();
+  return qs
+    ? `${MODELS_LIST_PATH}/${modelId}?${qs}`
+    : `${MODELS_LIST_PATH}/${modelId}`;
+}

--- a/src/lib/logic/api-error.ts
+++ b/src/lib/logic/api-error.ts
@@ -50,3 +50,14 @@ export function formatCommunicationsApiError(err: unknown): string {
   }
   return err instanceof Error ? err.message : 'Request failed';
 }
+
+export function formatEmailTemplatesApiError(err: unknown): string {
+  if (isAxiosLikeError(err)) {
+    return (
+      err.response?.data?.message ??
+      err.message ??
+      'Failed to load email templates'
+    );
+  }
+  return err instanceof Error ? err.message : 'Failed to load email templates';
+}


### PR DESCRIPTION
## Summary
- Moves email and unified template fetching off the server render path for `/communications/test` and `/communications/templates`.
- Shows inline loading and error states when `GET /email/templates` fails, instead of crashing into the redacted Module Error boundary.
- Adds degraded-mode UI when the unified templates API is unavailable, and preserves session-timeout redirects in communications server actions.
- Preserves models list filter/pagination state when navigating into and back from a model detail view (`owner`, `page`, `search`).

## Why
On experimental.dev, both pages failed during server-side `getTemplates()` while other communications routes worked. The same UI works locally, so the failure is environment-specific. Client-side fetching surfaces actionable errors in production and keeps SMS, push, and email-only flows usable when template APIs are down.

Separately, the models list already stored filters in the URL, but navigating into a model detail and clicking **Models** always returned to the unfiltered list. List state is now carried via a `list` query param on the detail URL and restored on back navigation.

## Related PR
- Conduit backend: https://github.com/ConduitPlatform/Conduit/pull/1567

## Test plan
- [ ] Open `/communications/test` and `/communications/templates` on localhost — both load normally.
- [ ] Stop the Conduit API and reload — pages show inline template errors, not Module Error.
- [ ] Confirm unified-only actions are hidden when the unified API is unavailable.
- [ ] Go to `/database/models?owner=database&page=2`, open a model, then click **Models** — returns to the filtered, paginated list.
- [ ] Switch models via the model switcher on detail — `list` param persists; back still restores the original list state.
- [ ] Switch detail tabs (Schema / Data / Settings) — `list` param remains in the URL.