### PR TITLE
fix: validate proxy env vars and add .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,18 @@ Learn more: [Website](https://getconduit.dev)
 - Desire to create something awesome
 
 # Quickstart
-This script uses docker compose to spin up some basic modules for you to test.
+
+You need a running [Conduit](https://github.com/ConduitPlatform/Conduit) instance (Admin API on port **3030** by default).
+Docker Compose or `@conduitplatform/cli` (`conduit deploy setup`) is the usual way to run it locally.
+
+```bash
+yarn install && npx lerna run build
 ```
-yarn install && npx lerna run build 
+
+Copy `apps/Conduit-UI/.env.example` to `apps/Conduit-UI/.env.local` and set `CONDUIT_URL` and `MASTER_KEY`.
+
+```bash
+cd ./apps/Conduit-UI && yarn dev
 ```
-```
-cd ./apps/Conduit-UI && yarn start 
-```
-Open http://localhost:8080 to check the admin panel (username:admin, password: admin)
+
+Open http://localhost:8080 (default login: `admin` / `admin`).

--- a/apps/Conduit-UI/.env.example
+++ b/apps/Conduit-UI/.env.example
@@ -1,0 +1,12 @@
+# Conduit Admin API (required) — NOT the Client API (:3000)
+CONDUIT_URL=http://localhost:3030
+
+# Conduit core master key (required)
+MASTER_KEY=M4ST3RK3Y
+
+# Optional: metrics and logs tabs in the admin panel
+# PROMETHEUS_URL=http://localhost:9090
+# LOKI_URL=http://localhost:3100
+
+# Optional: multi-tenant namespace
+# CONDUIT_NAMESPACE=

--- a/apps/Conduit-UI/src/pages/api/[...path].ts
+++ b/apps/Conduit-UI/src/pages/api/[...path].ts
@@ -46,6 +46,21 @@ export default (req: NextApiRequest, res: NextApiResponse) =>
         target: process.env.PROMETHEUS_URL,
       };
     } else {
+      if (!process.env.CONDUIT_URL?.trim()) {
+        res.status(500).json({
+          error:
+            'CONDUIT_URL is not set. Point it at the Conduit Admin API (e.g. http://localhost:3030).',
+        });
+        return resolve({});
+      }
+
+      if (!process.env.MASTER_KEY?.trim()) {
+        res.status(500).json({
+          error: 'MASTER_KEY is not set. Use the same master key as your Conduit core instance.',
+        });
+        return resolve({});
+      }
+
       // removes the api prefix from url
       req.url = req.url?.replace(/^\/api/, '');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Validate `CONDUIT_URL` and `MASTER_KEY` in the Next.js API proxy before forwarding to Conduit Admin API, returning explicit 500 JSON errors when either is missing.
- Add `apps/Conduit-UI/.env.example` documenting required and optional environment variables.
- Update README quickstart to reference env setup and correct Admin API port (3030).

## Context

Login failures with opaque errors often trace to unset `CONDUIT_URL` (Admin API base URL) or `MASTER_KEY`. This makes misconfiguration easier to diagnose.

## Test plan

- [ ] Start UI without env vars → `POST /api/login` returns 500 with clear error message
- [ ] Set `CONDUIT_URL` and `MASTER_KEY` → login succeeds against running Conduit instance
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbee1c93-d150-4278-995a-f128c48cd1b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbee1c93-d150-4278-995a-f128c48cd1b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

