### PR TITLE
fix(database): keep custom queries sidebar from overflowing the page

### DIFF
--- a/src/app/(dashboard)/(modules)/database/queries/layout.tsx
+++ b/src/app/(dashboard)/(modules)/database/queries/layout.tsx
@@ -17,6 +17,8 @@ type LayoutProps = {
   children: React.ReactNode;
 };
 
+const PAGE_SIZE = 10;
+
 export default function QueryLayout({ children }: Readonly<LayoutProps>) {
   const [searchTerm, setSearchTerm] = React.useState<string>();
   const [selectedModel, setSelectedModel] = React.useState<string>();
@@ -26,10 +28,16 @@ export default function QueryLayout({ children }: Readonly<LayoutProps>) {
   const [isLoading, setIsLoading] = React.useState(false);
   const [hasMore, setHasMore] = React.useState(true);
   const [page, setPage] = React.useState(1);
+  const [scrollRoot, setScrollRoot] = React.useState<HTMLDivElement | null>(
+    null
+  );
   const router = useRouter();
   const { toast } = useToast();
+  const requestIdRef = React.useRef(0);
   const { ref, inView } = useInView({
     threshold: 0,
+    root: scrollRoot,
+    rootMargin: '80px',
   });
 
   const fetchQueries = React.useCallback(
@@ -39,62 +47,81 @@ export default function QueryLayout({ children }: Readonly<LayoutProps>) {
       _model?: string,
       shouldClean?: boolean
     ) => {
+      const requestId = shouldClean
+        ? ++requestIdRef.current
+        : requestIdRef.current;
       setIsLoading(true);
 
-      const { customEndpoints: newQueries, count } = await getCustomEndpoints({
-        skip: (_page - 1) * 10,
-        limit: 10,
-        sort: 'createdAt',
-        search: !_term || isEmpty(_term) ? undefined : _term,
-        schemaName: _model ? [_model] : undefined,
-      });
+      try {
+        const { customEndpoints: newQueries, count } = await getCustomEndpoints(
+          {
+            skip: (_page - 1) * PAGE_SIZE,
+            limit: PAGE_SIZE,
+            sort: 'createdAt',
+            search: !_term || isEmpty(_term) ? undefined : _term,
+            schemaName: _model ? [_model] : undefined,
+          }
+        );
 
-      setQueries(prev => {
-        if (shouldClean) {
-          return newQueries;
+        if (requestId !== requestIdRef.current) {
+          return;
         }
-        // check that newQueries are not already in the queries
-        const existingQueries = prev.map(query => query._id);
-        const filteredQueries =
-          newQueries?.filter(query => !existingQueries.includes(query._id)) ??
-          [];
-        return [...prev, ...(filteredQueries ?? [])];
-      });
-      setHasMore(
-        newQueries?.length > 0 && count > (_page - 1) * 10 + newQueries?.length
-      );
-      setPage(prev => prev + 1);
-      setIsLoading(false);
+
+        const incoming = newQueries ?? [];
+        setQueries(prev => {
+          if (shouldClean) {
+            return incoming;
+          }
+          const existingIds = new Set(prev.map(query => query._id));
+          const filteredQueries = incoming.filter(
+            query => !existingIds.has(query._id)
+          );
+          return [...prev, ...filteredQueries];
+        });
+        setHasMore(
+          incoming.length > 0 &&
+            count > (_page - 1) * PAGE_SIZE + incoming.length
+        );
+        setPage(_page);
+      } finally {
+        if (requestId === requestIdRef.current) {
+          setIsLoading(false);
+        }
+      }
     },
     []
   );
 
-  // Mock function to fetch models
   const fetchModels = React.useCallback(async () => {
     const { schemas } = await getSchemas({});
     setModels(schemas);
-  }, [setModels]);
-
-  // Initial data fetch
-  React.useEffect(() => {
-    fetchModels();
   }, []);
 
-  // Load more when scrolling to the bottom
   React.useEffect(() => {
-    if (inView && hasMore && !isLoading) {
-      fetchQueries(page, searchTerm, selectedModel, false);
-    }
-  }, [inView, hasMore, isLoading, fetchQueries, page]);
+    fetchModels();
+  }, [fetchModels]);
 
-  // Reset pagination and queries when searchTerm or selectedModel changes
   React.useEffect(() => {
-    if (!searchTerm && !selectedModel) {
-      return;
-    }
+    setQueries([]);
     setPage(1);
+    setHasMore(true);
     fetchQueries(1, searchTerm, selectedModel, true);
-  }, [searchTerm, selectedModel]);
+  }, [searchTerm, selectedModel, fetchQueries]);
+
+  React.useEffect(() => {
+    if (inView && hasMore && !isLoading && queries.length > 0) {
+      fetchQueries(page + 1, searchTerm, selectedModel, false);
+    }
+  }, [
+    inView,
+    hasMore,
+    isLoading,
+    fetchQueries,
+    page,
+    searchTerm,
+    selectedModel,
+    queries.length,
+  ]);
 
   const handleCreateQuery = () => {
     router.push(`/database/queries/new`);
@@ -140,8 +167,8 @@ export default function QueryLayout({ children }: Readonly<LayoutProps>) {
   );
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col">
-      <div className="flex min-h-0 flex-1 gap-x-4 px-4 pb-4">
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
+      <div className="flex min-h-0 flex-1 gap-x-4 overflow-hidden px-4 pb-4">
         <QueryList
           queries={queries}
           models={models}
@@ -155,6 +182,7 @@ export default function QueryLayout({ children }: Readonly<LayoutProps>) {
           onCreateQuery={handleCreateQuery}
           onDeleteQuery={handleDeleteQuery}
           loadMoreRef={ref}
+          scrollRootRef={setScrollRoot}
         />
 
         <div className="min-h-0 flex-1 overflow-auto rounded-lg border bg-background shadow-xs">

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -9,9 +9,9 @@ export default function Layout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <ModuleAvailabilityProvider>
-      <div className="flex w-full">
+      <div className="flex h-dvh min-h-0 w-full overflow-hidden">
         <AppSidebar />
-        <main className="relative flex flex-col flex-1 min-h-svh bg-background md:ml-[52px]">
+        <main className="relative flex h-dvh min-h-0 flex-1 flex-col overflow-hidden bg-background md:ml-[52px]">
           <ModuleGuard>{children}</ModuleGuard>
         </main>
         <CommandPalette />

--- a/src/app/(dashboard)/template.tsx
+++ b/src/app/(dashboard)/template.tsx
@@ -104,7 +104,7 @@ export default function ModuleHeader({
     return (
       <>
         <LogsDrawer isSidebarOpen={false} />
-        <div className="page-enter-children">{children}</div>
+        <div className="page-enter-children h-full min-h-0">{children}</div>
       </>
     );
 
@@ -170,8 +170,8 @@ export default function ModuleHeader({
     isCommunicationsSubRoute && pathSegments[1] === 'templates';
 
   return (
-    <div className="flex flex-col overflow-x-auto no-scrollbar">
-      <div className="flex flex-row w-full justify-between px-4 py-2 border-b items-center sticky top-0 z-40 bg-background min-h-10">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="flex min-h-10 w-full shrink-0 flex-row items-center justify-between border-b bg-background px-4 py-2">
         <div className="flex items-center gap-3 min-w-0">
           <Breadcrumb>
             <BreadcrumbList>
@@ -361,8 +361,8 @@ export default function ModuleHeader({
           </DropdownMenu>
         </div>
       </div>
-      <div className="w-full h-full max-h-[90vh] main-scrollbar top-10">
-        <div className="page-enter-children px-6 py-4 mx-auto max-w-(--breakpoint-2xl) overflow-x-auto">
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <div className="page-enter-children mx-auto h-full min-h-0 max-w-(--breakpoint-2xl) overflow-auto px-6 py-4 main-scrollbar">
           {children}
         </div>
       </div>

--- a/src/components/database/queries/query-list/query-filters.tsx
+++ b/src/components/database/queries/query-list/query-filters.tsx
@@ -26,7 +26,7 @@ export function QueryFilters({
   models,
 }: Readonly<QueryFiltersProps>) {
   return (
-    <div className="p-4 space-y-4 border-b">
+    <div className="shrink-0 space-y-4 border-b p-4">
       <div className="flex items-center space-x-2">
         <Search className="w-4 h-4 text-muted-foreground" />
         <Input

--- a/src/components/database/queries/query-list/query-list.tsx
+++ b/src/components/database/queries/query-list/query-list.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Plus, Download } from 'lucide-react';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { Plus, Download, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { QueryListItem } from './query-list-item';
 import { QueryListSkeleton } from './query-list-skeleton';
@@ -29,6 +28,7 @@ interface QueryListProps {
   onCreateQuery: () => void;
   onDeleteQuery?: (id: string) => void;
   loadMoreRef: React.Ref<HTMLDivElement>;
+  scrollRootRef: (node: HTMLDivElement | null) => void;
 }
 
 export function QueryList({
@@ -44,9 +44,28 @@ export function QueryList({
   onCreateQuery,
   onDeleteQuery,
   loadMoreRef,
+  scrollRootRef,
 }: Readonly<QueryListProps>) {
   const [exportImportDialog, setExportImportDialog] = React.useState(false);
+  const listRef = React.useRef<HTMLDivElement | null>(null);
   const { toast } = useToast();
+
+  const isInitialLoading = isLoading && queries.length === 0;
+  const isLoadingMore = isLoading && queries.length > 0;
+
+  const setListNode = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      listRef.current = node;
+      scrollRootRef(node);
+    },
+    [scrollRootRef]
+  );
+
+  React.useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = 0;
+    }
+  }, [searchTerm, selectedModel]);
 
   const handleExport = () => {
     exportCustomEndpoints()
@@ -82,8 +101,6 @@ export function QueryList({
           title: 'Import Successful',
           description: 'Custom endpoints have been imported successfully.',
         });
-        // Note: The parent component should handle refreshing the queries list
-        // This would typically be done by calling a refresh function passed as a prop
       })
       .catch(error => {
         console.error(error);
@@ -94,6 +111,7 @@ export function QueryList({
         });
       });
   };
+
   return (
     <div className="flex h-full min-h-0 w-64 shrink-0 flex-col overflow-hidden rounded-lg border shadow-xs">
       <QueryFilters
@@ -104,41 +122,56 @@ export function QueryList({
         models={models}
       />
 
-      <div className="flex-1 overflow-hidden flex flex-col">
-        <ScrollArea className="flex-1">
-          <div className="p-4">
-            {isLoading &&
-              Array.from({ length: 3 }).map((_, i) => (
-                <QueryListSkeleton key={`skeleton-${i}`} />
-              ))}
-            {queries.map(query => (
-              <QueryListItem
-                key={query._id}
-                query={query}
-                isSelected={selectedQuery === query._id}
-                onClick={() => onQuerySelect(query._id)}
-                onDelete={onDeleteQuery}
-              />
+      <div
+        ref={setListNode}
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain main-scrollbar"
+      >
+        <div className="p-4">
+          {isInitialLoading &&
+            Array.from({ length: 3 }).map((_, i) => (
+              <QueryListSkeleton key={`skeleton-${i}`} />
             ))}
-
-            <div ref={loadMoreRef} className="h-4" />
-          </div>
-        </ScrollArea>
-        <div className="p-4 border-t mt-auto space-y-2">
-          <Button className="w-full" onClick={onCreateQuery}>
-            <Plus className="w-4 h-4 mr-2" />
-            New Query
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={() => setExportImportDialog(true)}
+          {queries.map(query => (
+            <QueryListItem
+              key={query._id}
+              query={query}
+              isSelected={selectedQuery === query._id}
+              onClick={() => onQuerySelect(query._id)}
+              onDelete={onDeleteQuery}
+            />
+          ))}
+          {!isInitialLoading && queries.length === 0 && (
+            <p className="px-1 py-6 text-center text-sm text-muted-foreground text-pretty">
+              {searchTerm || selectedModel
+                ? 'No queries match the current filters.'
+                : 'No custom queries yet.'}
+            </p>
+          )}
+          <div
+            ref={loadMoreRef}
+            className="flex h-8 items-center justify-center"
           >
-            <Download className="w-4 h-4 mr-1" />
-            Export/Import
-          </Button>
+            {isLoadingMore && (
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            )}
+          </div>
         </div>
+      </div>
+
+      <div className="mt-auto shrink-0 space-y-2 border-t p-4">
+        <Button className="w-full" onClick={onCreateQuery}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Query
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={() => setExportImportDialog(true)}
+        >
+          <Download className="mr-1 h-4 w-4" />
+          Export/Import
+        </Button>
       </div>
 
       <ExportImportDialog


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

## Summary

The custom queries sidebar on `/database/queries/new` grew with the full list and overflowed the page, making it hard to reach later queries or the editor.

This change:

- Locks the dashboard shell to remaining viewport height (header + fill-the-rest content) so `h-full` split panes are actually bounded
- Replaces the sidebar `ScrollArea` with a native `overflow-y-auto` list and keeps New Query / Export pinned at the bottom
- Roots infinite scroll (`limit: 10`) on the list container, fetches page 1 on mount and when filters change, and shows skeletons only on the initial load

## Test plan

- Open `/database/queries/new` with many custom queries
- Confirm the sidebar scrolls independently and the page does not grow
- Scroll to the bottom of the list and confirm the next page loads
- Search / filter by model resets to page 1 and scrolls from the top
- Empty results show the sidebar empty copy
- Editor pane still scrolls independently
- Spot-check a tall settings page still scrolls in the module shell

## Verification in this environment

- `pnpm lint` and `tsc --noEmit` pass (no new issues in touched files)
- Layout fixture matching the new height chain: sidebar list scrolls internally, New Query stays visible, header stays put, editor scrolls independently, no window scrollbar
- Login page still fills the viewport after the dashboard `h-dvh` change
- Authenticated `/database/queries/new` could not be exercised here (no Conduit backend session)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54465540-95a1-4460-b183-6bb044fe55c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54465540-95a1-4460-b183-6bb044fe55c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

