### PR TITLE
Update Cloud Agent dev environment: turbo install + local Conduit 0.17 backend

### DIFF
--- a/.cursor/conduit-backend/docker-compose.yml
+++ b/.cursor/conduit-backend/docker-compose.yml
@@ -1,0 +1,54 @@
+# Conduit backend (standalone) for local development of the Conduit Admin UI.
+#
+# Runs a self-contained Conduit instance (all modules in one image) backed by
+# Redis and MongoDB. The admin panel (run from source via `yarn dev`) connects
+# to the admin HTTP API exposed on http://localhost:3030 using MASTER_KEY.
+#
+# Derived from ConduitPlatform/Conduit docker/docker-compose.standalone.yml,
+# trimmed to the backend services (the UI is run from this repo's source).
+#
+# NOTE: host networking is used because Docker bridge networking is not
+# reliable inside the nested Cloud Agent VM (nftables/iptables are restricted).
+# With host networking every service shares the host network namespace, so
+# services reach each other over localhost and published ports map 1:1.
+services:
+  mongodb:
+    container_name: 'conduit-mongo'
+    image: 'docker.io/library/mongo:4.4.15'
+    restart: unless-stopped
+    network_mode: 'host'
+    environment:
+      MONGO_INITDB_DATABASE: 'conduit'
+      MONGO_INITDB_ROOT_USERNAME: 'conduit'
+      MONGO_INITDB_ROOT_PASSWORD: 'pass'
+    volumes:
+      - mongo:/data/db
+
+  redis:
+    container_name: 'conduit-redis'
+    image: 'docker.io/library/redis:7.0.2'
+    restart: unless-stopped
+    network_mode: 'host'
+
+  conduit:
+    container_name: 'conduit'
+    image: 'docker.io/conduitplatform/conduit-standalone:${CONDUIT_IMAGE_TAG:-0.17.0-alpha.6}'
+    restart: unless-stopped
+    network_mode: 'host'
+    depends_on:
+      - redis
+      - mongodb
+    environment:
+      REDIS_HOST: '127.0.0.1'
+      REDIS_PORT: '6379'
+      MASTER_KEY: '${CORE_MASTER_KEY:-M4ST3RK3Y}'
+      ADMIN_HTTP_PORT: '3030'
+      ADMIN_SOCKET_PORT: '3031'
+      CLIENT_HTTP_PORT: '3000'
+      CLIENT_SOCKET_PORT: '3001'
+      __DEFAULT_HOST_URL: '${ADMIN_DEFAULT_HOST_URL:-http://localhost:3030}'
+      DB_CONN_URI: 'mongodb://conduit:pass@127.0.0.1:27017/conduit?authSource=admin'
+
+volumes:
+  mongo:
+    external: false

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,7 @@
 {
   "name": "Conduit Admin UI",
   "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
   "terminals": [
     {
       "name": "Conduit-UI dev server",

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -13,13 +13,20 @@ cd "$REPO_ROOT"
 corepack enable >/dev/null 2>&1 || true
 corepack prepare yarn@1.22.22 --activate >/dev/null 2>&1 || true
 
+if ! command -v yarn >/dev/null 2>&1; then
+  echo "yarn is not available; enable corepack or install yarn 1.x before running this script." >&2
+  exit 1
+fi
+
 echo "Using node $(node -v) and yarn $(yarn -v)"
 
 # Install all workspace dependencies from the committed lockfile.
 yarn install --frozen-lockfile
 
-# Build the shared component library (required by the app) and the Next.js app.
+# Build the shared component library (required by the dev server) and the
+# Next.js app via the repo's canonical build pipeline (turbo). Turbo caches
+# task outputs, so repeat runs of this idempotent script are near-instant.
 # CI=false mirrors the repo's CI so Next build warnings are not treated as errors.
-CI=false npx lerna run build
+CI=false yarn build
 
 echo "Conduit Admin UI environment is ready."

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -29,4 +29,40 @@ yarn install --frozen-lockfile
 # CI=false mirrors the repo's CI so Next build warnings are not treated as errors.
 CI=false yarn build
 
+# ---------------------------------------------------------------------------
+# Docker Engine (for the local Conduit backend the admin panel connects to).
+#
+# The admin panel is only useful against a running Conduit instance, so the
+# `start` script brings up a Conduit 0.17 backend via Docker Compose. Here we
+# just make sure the Docker Engine is installed and configured. This is
+# best-effort: if it fails, the frontend still builds and runs (it simply
+# has no backend to talk to until Docker is available).
+# ---------------------------------------------------------------------------
+setup_docker() {
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "WARNING: sudo not available; skipping Docker setup (backend will be unavailable)." >&2
+    return 0
+  fi
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Installing Docker Engine..."
+    curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+    sudo sh /tmp/get-docker.sh
+  fi
+
+  # Bridge networking and the overlayfs snapshotter are unreliable inside the
+  # nested Cloud Agent VM (restricted nftables/iptables; overlayfs whiteouts
+  # need privileges we don't have). The vfs storage driver sidesteps the
+  # overlayfs limitation; the compose file uses host networking to sidestep
+  # the bridge limitation.
+  sudo mkdir -p /etc/docker
+  if ! grep -qs '"vfs"' /etc/docker/daemon.json; then
+    echo '{ "features": { "containerd-snapshotter": false }, "storage-driver": "vfs" }' \
+      | sudo tee /etc/docker/daemon.json >/dev/null
+  fi
+  echo "Docker $(docker --version 2>/dev/null) is configured (storage-driver: vfs)."
+}
+
+setup_docker || echo "WARNING: Docker setup failed; the Conduit backend will be unavailable." >&2
+
 echo "Conduit Admin UI environment is ready."

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Per-boot startup for the Conduit Admin UI dev environment.
+#
+# Brings up a local Conduit 0.17 backend (via Docker Compose) and points the
+# admin panel at it by writing apps/Conduit-UI/.env.local, which `yarn dev`
+# (the dev-server terminal) loads automatically. Everything here is
+# best-effort: a backend hiccup must not stop the container from starting, so
+# the frontend dev server always comes up either way.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COMPOSE_FILE=".cursor/conduit-backend/docker-compose.yml"
+CONDUIT_URL="http://localhost:3030"
+MASTER_KEY="M4ST3RK3Y"
+
+# Point the admin panel at the local backend. .env.local is git-ignored and is
+# loaded by Next.js at dev/build time (the API proxy reads CONDUIT_URL/MASTER_KEY).
+write_env_local() {
+  cat > apps/Conduit-UI/.env.local <<EOF
+CONDUIT_URL=${CONDUIT_URL}
+MASTER_KEY=${MASTER_KEY}
+EOF
+  echo "Wrote apps/Conduit-UI/.env.local (CONDUIT_URL=${CONDUIT_URL})."
+}
+
+write_env_local
+
+if ! command -v docker >/dev/null 2>&1 || ! command -v sudo >/dev/null 2>&1; then
+  echo "WARNING: docker/sudo unavailable; skipping Conduit backend startup." >&2
+  exit 0
+fi
+
+# Start the Docker daemon if it is not already running (no systemd in the VM).
+if ! sudo docker info >/dev/null 2>&1; then
+  echo "Starting Docker daemon..."
+  sudo bash -c 'nohup dockerd > /var/log/dockerd.log 2>&1 &'
+  for _ in $(seq 1 30); do
+    sudo docker info >/dev/null 2>&1 && break
+    sleep 2
+  done
+fi
+
+if ! sudo docker info >/dev/null 2>&1; then
+  echo "WARNING: Docker daemon did not start; Conduit backend is unavailable." >&2
+  exit 0
+fi
+
+echo "Bringing up the Conduit 0.17 backend (conduit-standalone + redis + mongo)..."
+sudo docker compose -f "$COMPOSE_FILE" up -d || \
+  echo "WARNING: 'docker compose up' failed; Conduit backend may be unavailable." >&2
+
+# Best-effort readiness wait so the panel can log in immediately after boot.
+for _ in $(seq 1 60); do
+  code="$(curl -sS -o /dev/null -w '%{http_code}' "${CONDUIT_URL}/ready" --max-time 3 2>/dev/null || true)"
+  if [ "$code" = "200" ]; then
+    echo "Conduit backend is ready at ${CONDUIT_URL} (admin login: admin / admin)."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "NOTE: Conduit backend not confirmed ready yet; it may still be initializing." >&2
+exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Cloud Agent development environment for the Conduit Admin UI in two parts:

1. **Canonical build in the install script** — `.cursor/install.sh` now uses the repo's `yarn build` (turbo) instead of `npx lerna run build` (consistent with `package.json`, plus turbo caching for near-instant idempotent re-runs), and guards for `yarn` availability.

2. **A real Conduit 0.17 backend for the panel to talk to** — the admin panel is only useful against a running Conduit instance, so the environment now brings one up automatically.

### Backend wiring
- `​.cursor/conduit-backend/docker-compose.yml`: runs Conduit 0.17 (`conduitplatform/conduit-standalone:0.17.0-alpha.6`) with Redis and MongoDB. Uses **host networking** and the **vfs** storage driver because bridge networking and the overlayfs snapshotter are unreliable inside the nested Cloud Agent VM (restricted nftables/iptables; overlayfs whiteouts need privileges we lack).
- `​.cursor/install.sh`: best-effort Docker Engine install + `vfs` daemon config, alongside the existing yarn install/build. Frontend-only use is unaffected if Docker is unavailable.
- `​.cursor/start.sh` (new, registered as `start`): starts `dockerd`, brings up the backend, waits for readiness, and writes `apps/Conduit-UI/.env.local` so the existing `yarn dev` terminal connects to `http://localhost:3030` with the default master key. Login is `admin` / `admin`.
- `​.cursor/environment.json`: registers the `start` script.

`.env.local` is git-ignored and written at boot, so no secrets are committed (the default `M4ST3RK3Y` is Conduit's well-known local default).

## Validation

The admin panel logs into the real Conduit 0.17 backend and loads module pages with live backend data:

[conduit_ui_login_and_dashboard_with_conduit_0_17_backend.mp4](https://cursor.com/agents/bc-d45132a0-549a-4e0a-94b3-587ff5d81712/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconduit_ui_login_and_dashboard_with_conduit_0_17_backend.mp4)

![Conduit dashboard after logging in against the 0.17 backend](https://cursor.com/artifacts/c/art-ff8f648c-b33d-4265-a38c-d337d5d0a925) ![Authentication module config loaded from backend](https://cursor.com/artifacts/c/art-be0facd6-fa77-4208-a723-8ce3d5075c9f)

**Fresh Cloud Agent** booted from a draft build of this branch (install + start) — all checks passed:
- `start.sh` cold-pulled the Conduit 0.17 images and brought up `conduit` + `conduit-redis` + `conduit-mongo`.
- `.env.local` written; backend `/ready` → 200; backend `POST /login` (admin/admin) → 200 + JWT.
- Frontend `/login` → 200; **proxied** `POST /api/login` (no masterkey header; proxy injects it) → 200 + JWT.

Also verified locally: idempotent `install.sh`/`start.sh`, and the browser demo above.

Note: this environment is DB-managed; the draft build was from this feature branch (testable, not promotable). Merge this PR so `main` carries the scripts, after which a promotable default-branch build can refresh the baseline.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d45132a0-549a-4e0a-94b3-587ff5d81712?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d45132a0-549a-4e0a-94b3-587ff5d81712&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

