### PR TITLE
fix(database): make custom queries a reliable developer workspace

### DIFF
--- a/src/app/(dashboard)/(modules)/database/queries/[id]/loading.tsx
+++ b/src/app/(dashboard)/(modules)/database/queries/[id]/loading.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function QueryEditorLoading() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b px-6 py-3">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-20" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-6 p-6 md:grid-cols-2">
+        <Skeleton className="h-80 w-full rounded-lg" />
+        <Skeleton className="h-80 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg md:col-span-2" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/(modules)/database/queries/[id]/page.tsx
+++ b/src/app/(dashboard)/(modules)/database/queries/[id]/page.tsx
@@ -1,7 +1,6 @@
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import {
   createCustomEndpoint,
-  deleteCustomEndpoint,
   getCustomEndpoint,
   patchCustomEndpoint,
 } from '@/lib/api/database';
@@ -18,7 +17,7 @@ function stripFormOnlyFields(data: SavePayload) {
 async function saveCustomQuery(
   endpointId: string | undefined,
   data: SavePayload
-) {
+): Promise<{ id: string }> {
   'use server';
   const payload = stripFormOnlyFields(data);
   try {
@@ -28,28 +27,21 @@ async function saveCustomQuery(
         endpointId,
         patchPayload as Partial<CustomEndpoint>
       );
-    } else {
-      await createCustomEndpoint(payload as Partial<CustomEndpoint>);
+      return { id: endpointId };
     }
+    const created = await createCustomEndpoint(
+      payload as Partial<CustomEndpoint>
+    );
+    if (!created?._id) {
+      throw new Error('Query was created but the server did not return an id.');
+    }
+    return { id: created._id };
   } catch (e: unknown) {
     console.error(e);
     throw new Error(
       (e as Error).message ?? 'Failed to save custom endpoint, check the logs'
     );
   }
-}
-
-async function deleteCustomQuery(id: string) {
-  'use server';
-  try {
-    await deleteCustomEndpoint(id);
-  } catch (e: unknown) {
-    console.error(e);
-    throw new Error(
-      (e as Error).message ?? 'Failed to delete custom endpoint, check the logs'
-    );
-  }
-  redirect('/database/queries/new');
 }
 
 export default async function CustomQueries(
@@ -66,23 +58,16 @@ export default async function CustomQueries(
     }
   } else {
     initialData = {
-      name: 'My new Query',
+      name: 'MyNewQuery',
       operation: 0,
     };
   }
 
   const handleSaveQuery = saveCustomQuery.bind(null, initialData._id);
-  const handleDeleteQuery = initialData._id
-    ? deleteCustomQuery.bind(null, initialData._id)
-    : undefined;
 
   return (
-    <div className="p-6">
-      <QueryEditor
-        initialData={initialData}
-        onSave={handleSaveQuery}
-        onDelete={handleDeleteQuery}
-      />
+    <div className="flex h-full min-h-0 flex-col">
+      <QueryEditor initialData={initialData} onSave={handleSaveQuery} />
     </div>
   );
 }

--- a/src/app/(dashboard)/(modules)/database/queries/layout.tsx
+++ b/src/app/(dashboard)/(modules)/database/queries/layout.tsx
@@ -1,8 +1,15 @@
 'use client';
+
 import * as React from 'react';
 import { useInView } from 'react-intersection-observer';
+import { useDebounce } from '@uidotdev/usehooks';
+import { usePathname, useRouter } from 'next/navigation';
+import { List } from 'lucide-react';
 import { QueryList } from '@/components/database/queries/query-list/query-list';
-import { useRouter } from 'next/navigation';
+import {
+  QueryWorkspaceProvider,
+  type PendingNavigation,
+} from '@/components/database/queries/query-workspace-context';
 import {
   deleteCustomEndpoint,
   getCustomEndpoints,
@@ -10,8 +17,25 @@ import {
 } from '@/lib/api/database';
 import { CustomEndpoint } from '@/lib/models/database/custom-endpoints';
 import { DeclaredSchema } from '@/lib/models/database';
-import { isEmpty } from 'lodash';
 import { useToast } from '@/lib/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 
 type LayoutProps = {
   children: React.ReactNode;
@@ -19,21 +43,50 @@ type LayoutProps = {
 
 const PAGE_SIZE = 10;
 
+function selectedIdFromPath(pathname: string) {
+  const match = pathname.match(/\/database\/queries\/([^/]+)/);
+  const id = match?.[1];
+  if (!id || id === 'new') return undefined;
+  return id;
+}
+
 export default function QueryLayout({ children }: Readonly<LayoutProps>) {
-  const [searchTerm, setSearchTerm] = React.useState<string>();
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const debouncedSearch = useDebounce(searchTerm, 300);
   const [selectedModel, setSelectedModel] = React.useState<string>();
-  const [selectedQuery, setSelectedQuery] = React.useState<string>();
   const [queries, setQueries] = React.useState<CustomEndpoint[]>([]);
   const [models, setModels] = React.useState<DeclaredSchema[]>([]);
   const [isLoading, setIsLoading] = React.useState(false);
   const [hasMore, setHasMore] = React.useState(true);
   const [page, setPage] = React.useState(1);
+  const [queriesError, setQueriesError] = React.useState<string | null>(null);
+  const [isDirty, setDirty] = React.useState(false);
+  const [pendingNavigation, setPendingNavigation] =
+    React.useState<PendingNavigation | null>(null);
+  const [pendingDelete, setPendingDelete] = React.useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const [listSheetOpen, setListSheetOpen] = React.useState(false);
+  const [isDesktop, setIsDesktop] = React.useState(true);
+
+  React.useEffect(() => {
+    const media = window.matchMedia('(min-width: 768px)');
+    const sync = () => setIsDesktop(media.matches);
+    sync();
+    media.addEventListener('change', sync);
+    return () => media.removeEventListener('change', sync);
+  }, []);
   const [scrollRoot, setScrollRoot] = React.useState<HTMLDivElement | null>(
     null
   );
+  const pathname = usePathname();
   const router = useRouter();
   const { toast } = useToast();
   const requestIdRef = React.useRef(0);
+  const selectedQueryId = selectedIdFromPath(pathname);
+
   const { ref, inView } = useInView({
     threshold: 0,
     root: scrollRoot,
@@ -51,14 +104,18 @@ export default function QueryLayout({ children }: Readonly<LayoutProps>) {
         ? ++requestIdRef.current
         : requestIdRef.current;
       setIsLoading(true);
+      if (shouldClean) {
+        setQueriesError(null);
+      }
 
       try {
+        const search = _term?.trim() ? _term.trim() : undefined;
         const { customEndpoints: newQueries, count } = await getCustomEndpoints(
           {
             skip: (_page - 1) * PAGE_SIZE,
             limit: PAGE_SIZE,
             sort: 'createdAt',
-            search: !_term || isEmpty(_term) ? undefined : _term,
+            search,
             schemaName: _model ? [_model] : undefined,
           }
         );
@@ -83,6 +140,20 @@ export default function QueryLayout({ children }: Readonly<LayoutProps>) {
             count > (_page - 1) * PAGE_SIZE + incoming.length
         );
         setPage(_page);
+        setQueriesError(null);
+      } catch (error) {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Could not load custom queries.';
+        setQueriesError(message);
+        if (shouldClean) {
+          setQueries([]);
+          setHasMore(false);
+        }
       } finally {
         if (requestId === requestIdRef.current) {
           setIsLoading(false);
@@ -93,24 +164,38 @@ export default function QueryLayout({ children }: Readonly<LayoutProps>) {
   );
 
   const fetchModels = React.useCallback(async () => {
-    const { schemas } = await getSchemas({});
-    setModels(schemas);
-  }, []);
+    try {
+      const { schemas } = await getSchemas({});
+      setModels(schemas);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Could not load models',
+        description: 'Model filtering may be unavailable until you retry.',
+        variant: 'destructive',
+      });
+    }
+  }, [toast]);
 
   React.useEffect(() => {
-    fetchModels();
+    void fetchModels();
   }, [fetchModels]);
 
   React.useEffect(() => {
-    setQueries([]);
     setPage(1);
     setHasMore(true);
-    fetchQueries(1, searchTerm, selectedModel, true);
-  }, [searchTerm, selectedModel, fetchQueries]);
+    void fetchQueries(1, debouncedSearch, selectedModel, true);
+  }, [debouncedSearch, selectedModel, fetchQueries]);
 
   React.useEffect(() => {
-    if (inView && hasMore && !isLoading && queries.length > 0) {
-      fetchQueries(page + 1, searchTerm, selectedModel, false);
+    if (
+      inView &&
+      hasMore &&
+      !isLoading &&
+      queries.length > 0 &&
+      !queriesError
+    ) {
+      void fetchQueries(page + 1, debouncedSearch, selectedModel, false);
     }
   }, [
     inView,
@@ -118,77 +203,245 @@ export default function QueryLayout({ children }: Readonly<LayoutProps>) {
     isLoading,
     fetchQueries,
     page,
-    searchTerm,
+    debouncedSearch,
     selectedModel,
     queries.length,
+    queriesError,
   ]);
 
+  React.useEffect(() => {
+    if (!isDirty) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isDirty]);
+
+  const refreshQueries = React.useCallback(async () => {
+    await fetchQueries(1, debouncedSearch, selectedModel, true);
+  }, [debouncedSearch, fetchQueries, selectedModel]);
+
+  const requestNavigation = React.useCallback(
+    (navigate: PendingNavigation) => {
+      if (isDirty) {
+        setPendingNavigation(() => navigate);
+        return;
+      }
+      navigate();
+    },
+    [isDirty]
+  );
+
   const handleCreateQuery = () => {
-    router.push(`/database/queries/new`);
-    setSelectedQuery(undefined);
+    requestNavigation(() => {
+      setListSheetOpen(false);
+      router.push('/database/queries/new');
+    });
   };
 
   const handleSelectQuery = (id: string) => {
-    router.push(`/database/queries/${id}`);
-    setSelectedQuery(id);
+    requestNavigation(() => {
+      setListSheetOpen(false);
+      router.push(`/database/queries/${id}`);
+    });
   };
 
   const handleModelChange = (value: string) => {
     setSelectedModel(value === 'all' ? undefined : value);
   };
 
-  const handleDeleteQuery = React.useCallback(
-    async (id: string) => {
-      if (!window.confirm('Delete this custom query? This cannot be undone.')) {
-        return;
+  const requestDelete = React.useCallback((id: string, name: string) => {
+    setPendingDelete({ id, name });
+  }, []);
+
+  const handleConfirmDelete = async () => {
+    if (!pendingDelete) return;
+    const target = pendingDelete;
+    setIsDeleting(true);
+    try {
+      await deleteCustomEndpoint(target.id);
+      setQueries(prev => prev.filter(q => q._id !== target.id));
+      setPendingDelete(null);
+      setDirty(false);
+      toast({
+        title: 'Query deleted',
+        description: `${target.name} was removed.`,
+      });
+      if (selectedQueryId === target.id) {
+        router.push('/database/queries/new');
       }
-      try {
-        await deleteCustomEndpoint(id);
-        setQueries(prev => prev.filter(q => q._id !== id));
-        if (selectedQuery === id) {
-          setSelectedQuery(undefined);
-          router.push('/database/queries/new');
-        }
-        toast({
-          title: 'Query deleted',
-          description: 'The custom query was removed.',
-        });
-      } catch (error) {
-        console.error(error);
-        toast({
-          title: 'Delete failed',
-          description:
-            error instanceof Error ? error.message : 'Could not delete query.',
-          variant: 'destructive',
-        });
-      }
-    },
-    [router, selectedQuery, toast]
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Delete failed',
+        description:
+          error instanceof Error ? error.message : 'Could not delete query.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCancelPendingNavigation = () => {
+    setPendingNavigation(null);
+  };
+
+  const handleDiscardPendingNavigation = () => {
+    const navigate = pendingNavigation;
+    setPendingNavigation(null);
+    setDirty(false);
+    navigate?.();
+  };
+
+  const closeListSheet = React.useCallback(() => {
+    setListSheetOpen(false);
+  }, []);
+
+  const workspaceValue = React.useMemo(
+    () => ({
+      selectedQueryId,
+      isDirty,
+      setDirty,
+      requestNavigation,
+      refreshQueries,
+      requestDelete,
+      closeListSheet,
+    }),
+    [
+      closeListSheet,
+      isDirty,
+      refreshQueries,
+      requestDelete,
+      requestNavigation,
+      selectedQueryId,
+    ]
   );
 
-  return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
-      <div className="flex min-h-0 flex-1 gap-x-4 overflow-hidden px-4 pb-4">
-        <QueryList
-          queries={queries}
-          models={models}
-          selectedQuery={selectedQuery}
-          isLoading={isLoading}
-          searchTerm={searchTerm}
-          selectedModel={selectedModel}
-          onSearchChange={setSearchTerm}
-          onModelChange={handleModelChange}
-          onQuerySelect={handleSelectQuery}
-          onCreateQuery={handleCreateQuery}
-          onDeleteQuery={handleDeleteQuery}
-          loadMoreRef={ref}
-          scrollRootRef={setScrollRoot}
-        />
+  const listProps = {
+    queries,
+    models,
+    selectedQuery: selectedQueryId,
+    isLoading,
+    searchTerm,
+    selectedModel,
+    queriesError,
+    onSearchChange: setSearchTerm,
+    onModelChange: handleModelChange,
+    onQuerySelect: handleSelectQuery,
+    onCreateQuery: handleCreateQuery,
+    onDeleteQuery: requestDelete,
+    onRetry: () => fetchQueries(1, debouncedSearch, selectedModel, true),
+    loadMoreRef: ref,
+    scrollRootRef: setScrollRoot,
+  };
 
-        <div className="min-h-0 flex-1 overflow-auto rounded-lg border bg-background shadow-xs">
-          {children}
+  return (
+    <QueryWorkspaceProvider value={workspaceValue}>
+      <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
+        <div className="flex shrink-0 items-center gap-2 px-4 pb-2 md:hidden">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setListSheetOpen(true)}
+          >
+            <List className="mr-2 h-4 w-4" />
+            Queries
+          </Button>
+        </div>
+        <div className="flex min-h-0 flex-1 gap-x-4 overflow-hidden px-4 pb-4">
+          {isDesktop ? (
+            <div className="flex h-full min-h-0">
+              <QueryList {...listProps} />
+            </div>
+          ) : (
+            <Sheet open={listSheetOpen} onOpenChange={setListSheetOpen}>
+              <SheetContent
+                side="left"
+                className="flex w-80 flex-col p-0 sm:max-w-sm"
+              >
+                <SheetHeader className="border-b px-4 py-3 pr-12 text-left">
+                  <SheetTitle className="text-base">Queries</SheetTitle>
+                  <SheetDescription className="sr-only">
+                    Search, filter, and open custom endpoints.
+                  </SheetDescription>
+                </SheetHeader>
+                <QueryList {...listProps} />
+              </SheetContent>
+            </Sheet>
+          )}
+
+          <div className="min-h-0 flex-1 overflow-auto rounded-lg border bg-background shadow-xs">
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+
+      <AlertDialog
+        open={pendingNavigation !== null}
+        onOpenChange={open => {
+          if (!open) handleCancelPendingNavigation();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have unsaved changes in this query. Leaving this view will
+              discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleCancelPendingNavigation}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleDiscardPendingNavigation}>
+              Discard changes
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={open => {
+          if (!open && !isDeleting) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete custom query?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes{' '}
+              <span className="font-medium text-foreground">
+                {pendingDelete?.name}
+              </span>{' '}
+              from the platform. Existing data is not deleted, but clients that
+              call this endpoint will fail. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={isDeleting}
+              onClick={event => {
+                event.preventDefault();
+                void handleConfirmDelete();
+              }}
+            >
+              {isDeleting ? 'Deleting…' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </QueryWorkspaceProvider>
   );
 }

--- a/src/components/database/queries/editor/constants.tsx
+++ b/src/components/database/queries/editor/constants.tsx
@@ -97,12 +97,12 @@ export const valueSourceTypes = [
   },
   {
     value: ValueSourceTypeEnum.CUSTOM,
-    label: 'Custom Value',
+    label: 'Custom',
     description: 'Use a literal value baked into this endpoint.',
   },
   {
     value: ValueSourceTypeEnum.CONTEXT,
-    label: 'Context Value',
+    label: 'Context',
     description:
       'Use a runtime value such as user._id from the request context.',
   },

--- a/src/components/database/queries/editor/constants.tsx
+++ b/src/components/database/queries/editor/constants.tsx
@@ -90,7 +90,20 @@ export const assignmentOperations = [
 
 // Value source types
 export const valueSourceTypes = [
-  { value: ValueSourceTypeEnum.INPUT, label: 'Input' },
-  { value: ValueSourceTypeEnum.CUSTOM, label: 'Custom Value' },
-  { value: ValueSourceTypeEnum.CONTEXT, label: 'Context Value' },
+  {
+    value: ValueSourceTypeEnum.INPUT,
+    label: 'Input',
+    description: 'Use a request input defined above.',
+  },
+  {
+    value: ValueSourceTypeEnum.CUSTOM,
+    label: 'Custom Value',
+    description: 'Use a literal value baked into this endpoint.',
+  },
+  {
+    value: ValueSourceTypeEnum.CONTEXT,
+    label: 'Context Value',
+    description:
+      'Use a runtime value such as user._id from the request context.',
+  },
 ] as const;

--- a/src/components/database/queries/editor/constants.tsx
+++ b/src/components/database/queries/editor/constants.tsx
@@ -54,7 +54,7 @@ export const placementTypes = [
   },
   {
     value: LocationEnum.QUERY,
-    label: 'Search Parameter',
+    label: 'Search',
     description: 'URL query parameter (?key=value)',
   },
   {

--- a/src/components/database/queries/editor/query-assignment-row.tsx
+++ b/src/components/database/queries/editor/query-assignment-row.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import * as React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { Badge } from '@/components/ui/badge';
+import { InputField } from '@/components/ui/form-inputs/InputField';
+import SelectField from '@/components/ui/form-inputs/SelectField';
+import {
+  AssignmentActionEnum,
+  ValueSourceTypeEnum,
+  ValueTypeEnum,
+} from '@/lib/models/database/custom-endpoints';
+import { cn } from '@/lib/utils';
+import { assignmentOperations, valueSourceTypes } from './constants';
+import {
+  COMPACT_SELECT_TRIGGER,
+  compactFieldLabel,
+  QueryCollapsibleRow,
+  QueryEnumSelect,
+  QueryModelField,
+} from './query-compact-fields';
+import { getAssignmentSummary, getTypeIcon } from './utils';
+
+interface QueryAssignmentRowProps {
+  index: number;
+  modifiableFields: QueryModelField[];
+  onRemove: (index: number) => void;
+}
+
+export function QueryAssignmentRow({
+  index,
+  modifiableFields,
+  onRemove,
+}: QueryAssignmentRowProps) {
+  const form = useFormContext();
+  const prefix = `assignments.${index}`;
+  const schemaField = form.watch(`${prefix}.schemaField`) as string | undefined;
+  const sourceType = form.watch(
+    `${prefix}.assignmentField.type`
+  ) as ValueSourceTypeEnum;
+  const assignmentValue = form.watch(`${prefix}.assignmentField.value`) as
+    | string
+    | undefined;
+  const action = Number(form.watch(`${prefix}.action`)) as AssignmentActionEnum;
+  const inputs = (form.watch('inputs') as { name: string }[] | undefined) ?? [];
+  const isIncomplete = !schemaField;
+  const [open, setOpen] = React.useState(isIncomplete);
+  const labelClass = compactFieldLabel();
+  const actionLabel =
+    assignmentOperations.find(option => option.value === action)?.label ??
+    'Assign';
+
+  return (
+    <QueryCollapsibleRow
+      open={open}
+      onOpenChange={setOpen}
+      summary={getAssignmentSummary({
+        schemaField,
+        action,
+        sourceType,
+        value: assignmentValue,
+        index,
+      })}
+      isIncomplete={isIncomplete}
+      collapsedBadges={
+        !isIncomplete ? (
+          <span className="ml-auto flex min-w-0 items-center gap-1.5">
+            <Badge variant="outline" className="font-normal">
+              {actionLabel}
+            </Badge>
+            <Badge variant="secondary" className="font-normal">
+              {sourceType}
+            </Badge>
+          </span>
+        ) : null
+      }
+      removeLabel={`Remove set value ${index + 1}`}
+      removeTooltip="Remove this assignment from the draft. Save to persist."
+      onRemove={() => onRemove(index)}
+    >
+      <div className="grid grid-cols-1 gap-3 p-3 sm:grid-cols-4">
+        <SelectField
+          label="Field"
+          placeholder="Select field"
+          fieldName={`${prefix}.schemaField`}
+          className="min-w-0"
+          classNames={{
+            label: labelClass,
+            selectTrigger: COMPACT_SELECT_TRIGGER,
+          }}
+          options={modifiableFields.map(modelField => ({
+            value: modelField.name,
+            label: (
+              <div className="flex items-center gap-2">
+                {getTypeIcon(modelField.type as ValueTypeEnum)}
+                <span className="font-mono text-[13px] slashed-zero">
+                  {modelField.name}
+                </span>
+                {modelField.isArray && (
+                  <Badge variant="outline" className="text-[10px] font-normal">
+                    Array
+                  </Badge>
+                )}
+              </div>
+            ),
+          }))}
+        />
+
+        <QueryEnumSelect
+          name={`${prefix}.action`}
+          label="Action"
+          options={assignmentOperations}
+        />
+
+        <SelectField
+          label="Source"
+          placeholder="Select source"
+          fieldName={`${prefix}.assignmentField.type`}
+          className="min-w-0"
+          classNames={{
+            label: labelClass,
+            selectTrigger: COMPACT_SELECT_TRIGGER,
+          }}
+          options={valueSourceTypes.map(source => ({
+            value: source.value,
+            label: source.label,
+          }))}
+        />
+
+        {sourceType === ValueSourceTypeEnum.INPUT && (
+          <div className="min-w-0">
+            {inputs.length === 0 ? (
+              <div className="space-y-1.5">
+                <p className={labelClass}>Value</p>
+                <p className="flex h-8 items-center rounded-md bg-muted/50 px-3 text-[13px] text-muted-foreground">
+                  Add an input first
+                </p>
+              </div>
+            ) : (
+              <SelectField
+                label="Value"
+                placeholder="Select input"
+                fieldName={`${prefix}.assignmentField.value`}
+                className="min-w-0"
+                classNames={{
+                  label: labelClass,
+                  selectTrigger: cn(
+                    COMPACT_SELECT_TRIGGER,
+                    'font-mono slashed-zero'
+                  ),
+                }}
+                options={inputs.map(input => ({
+                  value: input.name,
+                  label: input.name,
+                }))}
+              />
+            )}
+          </div>
+        )}
+
+        {sourceType === ValueSourceTypeEnum.CUSTOM && (
+          <InputField
+            label="Value"
+            fieldName={`${prefix}.assignmentField.value`}
+            placeholder="e.g. published"
+            classNames={{
+              label: labelClass,
+              input: 'font-mono text-[13px] slashed-zero',
+              formItem: 'min-w-0',
+            }}
+          />
+        )}
+
+        {sourceType === ValueSourceTypeEnum.CONTEXT && (
+          <InputField
+            label="Value"
+            fieldName={`${prefix}.assignmentField.value`}
+            placeholder="e.g. user._id"
+            info="Request context path, such as user._id. Resolved when the endpoint runs."
+            classNames={{
+              label: labelClass,
+              input: 'font-mono text-[13px] slashed-zero',
+              formItem: 'min-w-0',
+            }}
+          />
+        )}
+      </div>
+    </QueryCollapsibleRow>
+  );
+}

--- a/src/components/database/queries/editor/query-compact-fields.tsx
+++ b/src/components/database/queries/editor/query-compact-fields.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import * as React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { ChevronDown, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+  FormControl,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+export interface QueryModelField {
+  name: string;
+  type: string;
+  isArray: boolean;
+}
+
+export const COMPACT_SELECT_TRIGGER =
+  'h-8 border-0 bg-muted/50 px-3 text-[13px] font-normal shadow-none focus:ring-1 focus:ring-primary/50 focus:ring-offset-0 [&>span]:line-clamp-1 [&>span]:flex [&>span]:items-center';
+
+export function compactFieldLabel(hideOnDesktop?: boolean) {
+  return cn(
+    'pl-0 text-xs font-medium text-muted-foreground',
+    hideOnDesktop && 'sm:sr-only'
+  );
+}
+
+export function QueryEnumSelect({
+  name,
+  label,
+  options,
+  hideLabelOnDesktop,
+  onValueChange,
+}: {
+  name: string;
+  label: string;
+  options: ReadonlyArray<{ value: number; label: string }>;
+  hideLabelOnDesktop?: boolean;
+  onValueChange?: (value: number) => void;
+}) {
+  const form = useFormContext();
+
+  return (
+    <Controller
+      name={name}
+      control={form.control}
+      render={({ field }) => (
+        <FormItem
+          className={cn(
+            'min-w-0 space-y-1.5',
+            hideLabelOnDesktop && 'sm:space-y-0'
+          )}
+        >
+          <FormLabel className={compactFieldLabel(hideLabelOnDesktop)}>
+            {label}
+          </FormLabel>
+          <Select
+            value={String(field.value ?? options[0]?.value ?? 0)}
+            onValueChange={val => {
+              const next = Number(val);
+              field.onChange(next);
+              onValueChange?.(next);
+            }}
+          >
+            <FormControl>
+              <SelectTrigger className={COMPACT_SELECT_TRIGGER}>
+                <SelectValue placeholder={`Select ${label.toLowerCase()}`} />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {options.map(option => (
+                <SelectItem key={option.value} value={String(option.value)}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+export function QueryCollapsibleRow({
+  open,
+  onOpenChange,
+  summary,
+  isIncomplete,
+  collapsedBadges,
+  removeLabel,
+  removeTooltip,
+  onRemove,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  summary: string;
+  isIncomplete: boolean;
+  collapsedBadges?: React.ReactNode;
+  removeLabel: string;
+  removeTooltip: string;
+  onRemove: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={onOpenChange}
+      className={cn(
+        'overflow-hidden rounded-lg border border-border/60 bg-card',
+        isIncomplete && 'border-dashed border-primary/40'
+      )}
+    >
+      <div className="flex items-center gap-1 bg-muted/40 pr-1">
+        <CollapsibleTrigger className="flex min-h-10 min-w-0 flex-1 cursor-pointer items-center gap-2 px-3 py-2 text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring">
+          <ChevronDown
+            className={cn(
+              'size-4 shrink-0 text-muted-foreground motion-reduce:transition-none transition-transform',
+              open && 'rotate-180'
+            )}
+          />
+          <span className="min-w-0 truncate font-mono text-sm font-medium slashed-zero">
+            {summary}
+          </span>
+          {!open && collapsedBadges}
+        </CollapsibleTrigger>
+        <QueryRowRemoveButton
+          label={removeLabel}
+          tooltip={removeTooltip}
+          onRemove={onRemove}
+        />
+      </div>
+      <CollapsibleContent>
+        <div className="border-t border-border/60">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function QueryRowRemoveButton({
+  label,
+  tooltip,
+  onRemove,
+}: {
+  label: string;
+  tooltip: string;
+  onRemove: () => void;
+}) {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={label}
+            className="size-8 shrink-0"
+            onClick={onRemove}
+          >
+            <Trash2 className="size-4 text-destructive" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/database/queries/editor/query-condition-group.tsx
+++ b/src/components/database/queries/editor/query-condition-group.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import { useFormContext } from 'react-hook-form';
+import { Plus } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
+import {
+  Comparison,
+  ComparisonOperationEnum,
+  OperationsEnum,
+  ValueSourceTypeEnum,
+} from '@/lib/models/database/custom-endpoints';
+import { cn } from '@/lib/utils';
+import { QueryAssignmentRow } from './query-assignment-row';
+import { QueryModelField, QueryRowRemoveButton } from './query-compact-fields';
+import { QueryConditionRow } from './query-condition-row';
+
+type LogicType = 'AND' | 'OR';
+
+export function countConditions(group: unknown): number {
+  if (!group || typeof group !== 'object') return 0;
+  const nested = group as { AND?: unknown[]; OR?: unknown[] };
+  const items = nested.AND ?? nested.OR;
+  if (!Array.isArray(items)) return 0;
+  return items.reduce((count: number, condition: unknown) => {
+    if (
+      condition &&
+      typeof condition === 'object' &&
+      ('AND' in condition || 'OR' in condition)
+    ) {
+      return count + countConditions(condition);
+    }
+    return count + 1;
+  }, 0);
+}
+
+function isConditionGroup(
+  value: unknown
+): value is { AND?: unknown[]; OR?: unknown[] } {
+  return (
+    !!value && typeof value === 'object' && ('AND' in value || 'OR' in value)
+  );
+}
+
+function emptyFindCopy(operation: OperationsEnum): {
+  title: string;
+  detail: string;
+} {
+  switch (operation) {
+    case OperationsEnum.DELETE:
+      return {
+        title: 'No filters — this deletes every document',
+        detail: 'Add a condition unless you intend to match the entire model.',
+      };
+    case OperationsEnum.PUT:
+    case OperationsEnum.PATCH:
+      return {
+        title: 'No filters — this updates every document',
+        detail: 'Add a condition unless you intend to match the entire model.',
+      };
+    case OperationsEnum.POST:
+      return {
+        title: 'No find conditions',
+        detail: 'Create endpoints usually skip find filters.',
+      };
+    case OperationsEnum.GET:
+      return {
+        title: 'No filters — this returns every document',
+        detail: 'Add a condition to narrow the result set.',
+      };
+    default: {
+      const _exhaustive: never = operation;
+      return _exhaustive;
+    }
+  }
+}
+
+function QueryLogicToggle({
+  value,
+  onChange,
+}: {
+  value: LogicType;
+  onChange: (next: LogicType) => void;
+}) {
+  const options: { value: LogicType; hint: string }[] = [
+    { value: 'AND', hint: 'Every condition must match' },
+    { value: 'OR', hint: 'Any condition may match' },
+  ];
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Group logic"
+      className="grid grid-cols-2 gap-1 rounded-lg bg-muted/40 p-1"
+      onKeyDown={event => {
+        if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+        event.preventDefault();
+        onChange(value === 'AND' ? 'OR' : 'AND');
+      }}
+    >
+      {options.map(option => {
+        const isSelected = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            title={option.hint}
+            tabIndex={isSelected ? 0 : -1}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-md px-3 text-xs font-medium motion-reduce:transition-none transition-colors',
+              isSelected
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {option.value}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface QueryConditionGroupProps {
+  path?: string;
+  isNested?: boolean;
+  modelFields: QueryModelField[];
+  operation: OperationsEnum;
+}
+
+export function QueryConditionGroup({
+  path = 'query',
+  isNested = false,
+  modelFields,
+  operation,
+}: QueryConditionGroupProps) {
+  const form = useFormContext();
+  const groupRoot = form.watch(path) as { AND?: unknown; OR?: unknown };
+  const groupType: LogicType = groupRoot?.AND ? 'AND' : 'OR';
+  const conditions =
+    (form.watch(`${path}.${groupType}`) as unknown[] | undefined) ?? [];
+  const hasConditions = conditions.length > 0;
+  const nestedCount = countConditions(groupRoot);
+  const emptyCopy = isNested
+    ? {
+        title: `No conditions in this ${groupType} group`,
+        detail: 'Add a condition or another nested group.',
+      }
+    : emptyFindCopy(operation);
+
+  const setDirtyValue = (
+    target: string,
+    value: unknown,
+    shouldValidate = true
+  ) => {
+    form.setValue(target, value as never, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate,
+    });
+  };
+
+  const addCondition = () => {
+    const current = (form.getValues(`${path}.${groupType}`) as unknown[]) ?? [];
+    const hasInputs =
+      ((form.getValues('inputs') as unknown[]) ?? []).length > 0;
+    const condition: Comparison = {
+      schemaField: '',
+      operation: ComparisonOperationEnum.EQUAL,
+      comparisonField: {
+        type: hasInputs
+          ? ValueSourceTypeEnum.INPUT
+          : ValueSourceTypeEnum.CUSTOM,
+        value: '',
+      },
+    };
+    setDirtyValue(`${path}.${groupType}`, [...current, condition], false);
+  };
+
+  const addNestedGroup = () => {
+    const current = (form.getValues(`${path}.${groupType}`) as unknown[]) ?? [];
+    const nestedType: LogicType = groupType === 'AND' ? 'OR' : 'AND';
+    setDirtyValue(
+      `${path}.${groupType}`,
+      [...current, { [nestedType]: [] }],
+      false
+    );
+  };
+
+  const removeFromGroup = (parentPath: string, index: number) => {
+    const current = (form.getValues(parentPath) as unknown[]) ?? [];
+    const next = [...current];
+    next.splice(index, 1);
+    setDirtyValue(parentPath, next);
+  };
+
+  const switchLogic = (next: LogicType) => {
+    if (next === groupType) return;
+    const items = groupRoot?.AND ?? groupRoot?.OR ?? [];
+    setDirtyValue(path, { [next]: items });
+  };
+
+  return (
+    <div
+      className={cn(
+        isNested && 'rounded-lg border border-border/60 bg-muted/20'
+      )}
+    >
+      <div
+        className={cn(
+          'flex flex-wrap items-center gap-2',
+          isNested ? 'px-3 py-2' : 'pb-3'
+        )}
+      >
+        {!isNested && (
+          <div className="flex min-w-0 items-center gap-1.5">
+            <h3 className="text-sm font-medium">Find Conditions</h3>
+            <QueryFieldHint content="Documents must match this group. AND requires every condition; OR requires any condition." />
+            {hasConditions && (
+              <Badge variant="secondary" className="font-normal tabular-nums">
+                {nestedCount}
+              </Badge>
+            )}
+          </div>
+        )}
+
+        <QueryLogicToggle value={groupType} onChange={switchLogic} />
+        <p className="hidden text-xs text-muted-foreground sm:block">
+          {groupType === 'AND'
+            ? 'Every condition must match'
+            : 'Any condition may match'}
+        </p>
+
+        {isNested && (
+          <Badge variant={groupType === 'AND' ? 'secondary' : 'outline'}>
+            {nestedCount} condition{nestedCount !== 1 ? 's' : ''}
+          </Badge>
+        )}
+
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addCondition}
+          >
+            <Plus className="mr-1.5 size-3.5" />
+            Condition
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addNestedGroup}
+          >
+            <Plus className="mr-1.5 size-3.5" />
+            {groupType === 'AND' ? 'OR' : 'AND'} group
+          </Button>
+          {isNested && (
+            <QueryRowRemoveButton
+              label="Remove group"
+              tooltip="Remove this group from the draft. Save to persist."
+              onRemove={() => {
+                const pathParts = path.split('.');
+                const index = Number.parseInt(pathParts.pop() ?? '0', 10);
+                const parentPath = pathParts.join('.');
+                removeFromGroup(parentPath, index);
+              }}
+            />
+          )}
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          'space-y-2 border-l-2 pl-3',
+          isNested && 'px-3 pb-3',
+          groupType === 'AND'
+            ? 'border-primary/40'
+            : 'border-muted-foreground/30'
+        )}
+      >
+        {!hasConditions ? (
+          <div className="rounded-lg border border-dashed border-border/80 px-3 py-6 text-center">
+            <p className="text-sm text-foreground">{emptyCopy.title}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {emptyCopy.detail}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {conditions.map((condition, index) => {
+              const childPath = `${path}.${groupType}.${index}`;
+              if (isConditionGroup(condition)) {
+                return (
+                  <QueryConditionGroup
+                    key={childPath}
+                    path={childPath}
+                    isNested
+                    modelFields={modelFields}
+                    operation={operation}
+                  />
+                );
+              }
+              return (
+                <QueryConditionRow
+                  key={childPath}
+                  path={childPath}
+                  parentPath={`${path}.${groupType}`}
+                  index={index}
+                  modelFields={modelFields}
+                  onRemove={removeFromGroup}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface QueryAssignmentsProps {
+  fields: { id: string }[];
+  modifiableFields: QueryModelField[];
+  operationLabel: string;
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+}
+
+export function QueryAssignments({
+  fields,
+  modifiableFields,
+  operationLabel,
+  onAdd,
+  onRemove,
+}: QueryAssignmentsProps) {
+  const hasAssignments = fields.length > 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <h3 className="text-sm font-medium">Set Values</h3>
+          <QueryFieldHint content="Fields written when this Create, Update, or Patch endpoint runs." />
+          {hasAssignments && (
+            <Badge variant="secondary" className="font-normal tabular-nums">
+              {fields.length}
+            </Badge>
+          )}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="ml-auto"
+          onClick={onAdd}
+        >
+          <Plus className="mr-1.5 size-3.5" />
+          Set value
+        </Button>
+      </div>
+
+      {!hasAssignments ? (
+        <div className="rounded-lg border border-dashed border-border/80 px-3 py-6 text-center">
+          <p className="text-sm text-foreground">No values to write</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Add the fields this {operationLabel} operation should set.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {fields.map((field, index) => (
+            <QueryAssignmentRow
+              key={field.id}
+              index={index}
+              modifiableFields={modifiableFields}
+              onRemove={onRemove}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/database/queries/editor/query-condition-row.tsx
+++ b/src/components/database/queries/editor/query-condition-row.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import * as React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
+import { InputField } from '@/components/ui/form-inputs/InputField';
+import SelectField from '@/components/ui/form-inputs/SelectField';
+import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
+import {
+  ComparisonOperationEnum,
+  ValueSourceTypeEnum,
+  ValueTypeEnum,
+} from '@/lib/models/database/custom-endpoints';
+import { cn } from '@/lib/utils';
+import { comparisonOperations, valueSourceTypes } from './constants';
+import {
+  COMPACT_SELECT_TRIGGER,
+  compactFieldLabel,
+  QueryCollapsibleRow,
+  QueryEnumSelect,
+  QueryModelField,
+} from './query-compact-fields';
+import { getConditionSummary, getTypeIcon } from './utils';
+
+interface QueryConditionRowProps {
+  path: string;
+  parentPath: string;
+  index: number;
+  modelFields: QueryModelField[];
+  onRemove: (parentPath: string, index: number) => void;
+}
+
+export function QueryConditionRow({
+  path,
+  parentPath,
+  index,
+  modelFields,
+  onRemove,
+}: QueryConditionRowProps) {
+  const form = useFormContext();
+  const fieldName = (suffix: string) => `${path}.${suffix}`;
+  const schemaField = form.watch(fieldName('schemaField')) as
+    | string
+    | undefined;
+  const sourceType = form.watch(
+    fieldName('comparisonField.type')
+  ) as ValueSourceTypeEnum;
+  const comparisonValue = form.watch(fieldName('comparisonField.value')) as
+    | string
+    | undefined;
+  const like = Boolean(form.watch(fieldName('comparisonField.like')));
+  const caseSensitiveLike = Boolean(
+    form.watch(fieldName('comparisonField.caseSensitiveLike'))
+  );
+  const operation = Number(
+    form.watch(fieldName('operation'))
+  ) as ComparisonOperationEnum;
+  const inputs = (form.watch('inputs') as { name: string }[] | undefined) ?? [];
+  const isEqual = operation === ComparisonOperationEnum.EQUAL;
+  const isIncomplete = !schemaField;
+  const [open, setOpen] = React.useState(isIncomplete);
+  const labelClass = compactFieldLabel();
+  const comparisonLabel =
+    like && isEqual
+      ? 'Like'
+      : (comparisonOperations.find(option => option.value === operation)
+          ?.label ?? 'Equal');
+
+  return (
+    <QueryCollapsibleRow
+      open={open}
+      onOpenChange={setOpen}
+      summary={getConditionSummary({
+        schemaField,
+        operation,
+        sourceType,
+        value: comparisonValue,
+        like,
+        caseSensitiveLike,
+        index,
+      })}
+      isIncomplete={isIncomplete}
+      collapsedBadges={
+        !isIncomplete ? (
+          <span className="ml-auto flex min-w-0 items-center gap-1.5">
+            <Badge variant="outline" className="font-normal">
+              {comparisonLabel}
+            </Badge>
+            <Badge variant="secondary" className="font-normal">
+              {sourceType}
+            </Badge>
+          </span>
+        ) : null
+      }
+      removeLabel={`Remove condition ${index + 1}`}
+      removeTooltip="Remove this condition from the draft. Save to persist."
+      onRemove={() => onRemove(parentPath, index)}
+    >
+      <div className="grid grid-cols-1 gap-3 p-3 sm:grid-cols-4">
+        <SelectField
+          label="Field"
+          placeholder="Select field"
+          fieldName={fieldName('schemaField')}
+          className="min-w-0"
+          classNames={{
+            label: labelClass,
+            selectTrigger: COMPACT_SELECT_TRIGGER,
+          }}
+          options={modelFields.map(modelField => ({
+            value: modelField.name,
+            label: (
+              <div className="flex items-center gap-2">
+                {getTypeIcon(modelField.type as ValueTypeEnum)}
+                <span className="font-mono text-[13px] slashed-zero">
+                  {modelField.name}
+                </span>
+                {modelField.isArray && (
+                  <Badge variant="outline" className="text-[10px] font-normal">
+                    Array
+                  </Badge>
+                )}
+              </div>
+            ),
+          }))}
+        />
+
+        <QueryEnumSelect
+          name={fieldName('operation')}
+          label="Comparison"
+          options={comparisonOperations}
+          onValueChange={next => {
+            if (next !== ComparisonOperationEnum.EQUAL) {
+              form.setValue(fieldName('comparisonField.like'), false, {
+                shouldDirty: true,
+              });
+              form.setValue(
+                fieldName('comparisonField.caseSensitiveLike'),
+                false,
+                { shouldDirty: true }
+              );
+            }
+          }}
+        />
+
+        <SelectField
+          label="Source"
+          placeholder="Select source"
+          fieldName={fieldName('comparisonField.type')}
+          className="min-w-0"
+          classNames={{
+            label: labelClass,
+            selectTrigger: COMPACT_SELECT_TRIGGER,
+          }}
+          options={valueSourceTypes.map(source => ({
+            value: source.value,
+            label: source.label,
+          }))}
+        />
+
+        {sourceType === ValueSourceTypeEnum.INPUT && (
+          <div className="min-w-0">
+            {inputs.length === 0 ? (
+              <div className="space-y-1.5">
+                <p className={labelClass}>Value</p>
+                <p className="flex h-8 items-center rounded-md bg-muted/50 px-3 text-[13px] text-muted-foreground">
+                  Add an input first
+                </p>
+              </div>
+            ) : (
+              <SelectField
+                label="Value"
+                placeholder="Select input"
+                fieldName={fieldName('comparisonField.value')}
+                className="min-w-0"
+                classNames={{
+                  label: labelClass,
+                  selectTrigger: cn(
+                    COMPACT_SELECT_TRIGGER,
+                    'font-mono slashed-zero'
+                  ),
+                }}
+                options={inputs.map(input => ({
+                  value: input.name,
+                  label: input.name,
+                }))}
+              />
+            )}
+          </div>
+        )}
+
+        {sourceType === ValueSourceTypeEnum.CUSTOM && (
+          <InputField
+            label="Value"
+            fieldName={fieldName('comparisonField.value')}
+            placeholder="e.g. published"
+            classNames={{
+              label: labelClass,
+              input: 'font-mono text-[13px] slashed-zero',
+              formItem: 'min-w-0',
+            }}
+          />
+        )}
+
+        {sourceType === ValueSourceTypeEnum.CONTEXT && (
+          <InputField
+            label="Value"
+            fieldName={fieldName('comparisonField.value')}
+            placeholder="e.g. user._id"
+            info="Request context path, such as user._id. Resolved when the endpoint runs."
+            classNames={{
+              label: labelClass,
+              input: 'font-mono text-[13px] slashed-zero',
+              formItem: 'min-w-0',
+            }}
+          />
+        )}
+      </div>
+
+      {isEqual && (
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 border-t border-border/60 px-3 py-2">
+          <FormField
+            control={form.control}
+            name={fieldName('comparisonField.like')}
+            render={({ field }) => (
+              <FormItem className="flex min-h-8 flex-row items-center gap-2">
+                <FormControl>
+                  <Checkbox
+                    checked={Boolean(field.value)}
+                    onCheckedChange={checked => {
+                      const isChecked = Boolean(checked);
+                      field.onChange(isChecked);
+                      if (!isChecked) {
+                        form.setValue(
+                          fieldName('comparisonField.caseSensitiveLike'),
+                          false,
+                          { shouldDirty: true }
+                        );
+                      }
+                    }}
+                  />
+                </FormControl>
+                <div className="flex items-center gap-1">
+                  <FormLabel className="font-normal">Like</FormLabel>
+                  <QueryFieldHint content="Pattern match. Use % as a wildcard; the value is matched as %input%." />
+                </div>
+              </FormItem>
+            )}
+          />
+          {like && (
+            <FormField
+              control={form.control}
+              name={fieldName('comparisonField.caseSensitiveLike')}
+              render={({ field }) => (
+                <FormItem className="flex min-h-8 flex-row items-center gap-2">
+                  <FormControl>
+                    <Checkbox
+                      checked={Boolean(field.value)}
+                      onCheckedChange={checked =>
+                        field.onChange(Boolean(checked))
+                      }
+                    />
+                  </FormControl>
+                  <div className="flex items-center gap-1">
+                    <FormLabel className="font-normal">
+                      Case sensitive
+                    </FormLabel>
+                    <QueryFieldHint content="When off, matching is case-insensitive (e.g. ILIKE on PostgreSQL)." />
+                  </div>
+                </FormItem>
+              )}
+            />
+          )}
+        </div>
+      )}
+    </QueryCollapsibleRow>
+  );
+}

--- a/src/components/database/queries/editor/query-editor.tsx
+++ b/src/components/database/queries/editor/query-editor.tsx
@@ -17,13 +17,15 @@ import {
 import * as React from 'react';
 import { useEffect } from 'react';
 import {
-  ArrowLeft,
   BinaryIcon as LogicalOr,
+  Check,
   ChevronDown,
   Code,
+  Copy,
   FileJson,
   Filter,
   FormInput,
+  Loader2,
   Plus,
   PlusIcon as LogicalAnd,
   Save,
@@ -40,16 +42,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { toast } from '@/lib/hooks/use-toast';
@@ -62,6 +54,14 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import {
   Form,
   FormControl,
@@ -110,6 +110,14 @@ import {
   getReadableOperation,
   getTypeIcon,
 } from '@/components/database/queries/editor/utils';
+import { useQueryWorkspaceOptional } from '@/components/database/queries/query-workspace-context';
+import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
+import {
+  getEndpointPath,
+  getOperationMeta,
+} from '@/components/database/queries/query-operations';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
 
 interface ModelField {
   name: string;
@@ -200,25 +208,60 @@ type QueryFormValues = z.infer<typeof querySchema>;
 /** Nested condition paths are built at runtime; widen for react-hook-form APIs. */
 type QueryFormPath = FieldPath<QueryFormValues>;
 
+const INPUTS_JSON_PLACEHOLDER = `[
+  {
+    "name": "id",
+    "type": "String",
+    "location": 1,
+    "optional": false,
+    "array": false
+  }
+]`;
+
+const QUERY_JSON_PLACEHOLDER = `{
+  "query": {
+    "AND": [
+      {
+        "schemaField": "name",
+        "operation": 0,
+        "comparisonField": {
+          "type": "Input",
+          "value": "name"
+        }
+      }
+    ]
+  },
+  "assignments": [
+    {
+      "schemaField": "status",
+      "action": 0,
+      "assignmentField": {
+        "type": "Custom",
+        "value": "active"
+      }
+    }
+  ]
+}`;
+
 interface QueryEditorProps {
-  onBack?: () => void;
-  onSave?: (data: QueryFormValues) => Promise<void>;
-  onDelete?: () => Promise<void>;
+  onSave?: (data: QueryFormValues) => Promise<{ id: string } | void>;
   initialData?: Partial<CustomEndpoint>;
 }
 
 export function QueryEditor({
-  onBack,
   onSave,
-  onDelete,
   initialData,
 }: Readonly<QueryEditorProps>) {
+  const workspace = useQueryWorkspaceOptional();
+  const router = useRouter();
   const [models, setModels] = React.useState<DeclaredSchema[]>([]);
+  const [modelsLoading, setModelsLoading] = React.useState(true);
   const [isModelDialogOpen, setIsModelDialogOpen] = React.useState(false);
   const [modelSearchTerm, setModelSearchTerm] = React.useState('');
   const [inputMode, setInputMode] = React.useState<'form' | 'json'>('form');
   const [queryMode, setQueryMode] = React.useState<'form' | 'json'>('form');
-  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
+  const [saveShortcutLabel, setSaveShortcutLabel] = React.useState('Ctrl+S');
+  const [copiedPath, setCopiedPath] = React.useState(false);
 
   const form = useForm<QueryFormValues>({
     resolver: rhfZodResolver(querySchema),
@@ -256,6 +299,33 @@ export function QueryEditor({
     getValues,
   } = form;
   const selectedSchema = form.watch('selectedSchema');
+  const queryName = form.watch('name');
+
+  const setWorkspaceDirty = workspace?.setDirty;
+  React.useEffect(() => {
+    setWorkspaceDirty?.(isDirty);
+    return () => setWorkspaceDirty?.(false);
+  }, [isDirty, setWorkspaceDirty]);
+
+  React.useEffect(() => {
+    const platform = navigator.platform || navigator.userAgent;
+    setSaveShortcutLabel(
+      /Mac|iPhone|iPad|iPod/i.test(platform) ? '⌘S' : 'Ctrl+S'
+    );
+  }, []);
+
+  const setDirtyValue = (
+    path: string,
+    value: unknown,
+    options?: { shouldValidate?: boolean }
+  ) => {
+    form.setValue(path as QueryFormPath, value as never, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: options?.shouldValidate ?? true,
+    });
+  };
+
   const [modelFields, setModelFields] = React.useState<ModelField[]>([]);
   const [modifiableFields, setModifiableFields] = React.useState<ModelField[]>(
     []
@@ -330,7 +400,7 @@ export function QueryEditor({
   const addConditionToGroup = (path: string, condition: any) => {
     const currentGroup = form.getValues(path as any) as unknown[];
     const updatedConditions = [...currentGroup, condition];
-    form.setValue(path as any, updatedConditions);
+    setDirtyValue(path, updatedConditions);
   };
 
   const addNestedGroup = (path: string, groupType: 'AND' | 'OR') => {
@@ -339,14 +409,14 @@ export function QueryEditor({
       [groupType]: [],
     };
     const updatedConditions = [...currentGroup, newGroup];
-    form.setValue(path as any, updatedConditions);
+    setDirtyValue(path, updatedConditions);
   };
 
   const removeFromGroup = (path: string, index: number) => {
     const currentGroup = form.getValues(path as any) as unknown[];
     const updatedConditions = [...currentGroup];
     updatedConditions.splice(index, 1);
-    form.setValue(path as any, updatedConditions);
+    setDirtyValue(path, updatedConditions);
   };
 
   const {
@@ -373,7 +443,7 @@ export function QueryEditor({
             'This model does not support creating new entries through custom queries',
           variant: 'destructive',
         });
-        form.setValue('operation', OperationsEnum.GET);
+        form.setValue('operation', OperationsEnum.GET, { shouldDirty: true });
       }
     } else if (
       operation === OperationsEnum.PUT ||
@@ -389,7 +459,7 @@ export function QueryEditor({
             'This model does not support modifying entries through custom queries',
           variant: 'destructive',
         });
-        form.setValue('operation', OperationsEnum.GET);
+        form.setValue('operation', OperationsEnum.GET, { shouldDirty: true });
       }
     } else if (operation === OperationsEnum.DELETE) {
       if (!selectedModel.modelOptions?.conduit?.permissions?.canDelete) {
@@ -399,7 +469,7 @@ export function QueryEditor({
             'This model does not support deleting entries through custom queries',
           variant: 'destructive',
         });
-        form.setValue('operation', OperationsEnum.GET);
+        form.setValue('operation', OperationsEnum.GET, { shouldDirty: true });
       }
     }
   }, [operation]);
@@ -411,17 +481,29 @@ export function QueryEditor({
   ].includes(operation);
 
   const fetchModels = React.useCallback(async () => {
-    const { schemas } = await getSchemas({
-      skip: 0,
-      limit: 1000,
-    });
-    setModels(
-      schemas.filter(model => {
-        return (
-          model?.modelOptions?.conduit?.permissions?.canModify !== 'Nothing'
-        );
-      })
-    );
+    setModelsLoading(true);
+    try {
+      const { schemas } = await getSchemas({
+        skip: 0,
+        limit: 1000,
+      });
+      setModels(
+        schemas.filter(model => {
+          return (
+            model?.modelOptions?.conduit?.permissions?.canModify !== 'Nothing'
+          );
+        })
+      );
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Could not load models',
+        description: 'Select a model after retrying from the list filters.',
+        variant: 'destructive',
+      });
+    } finally {
+      setModelsLoading(false);
+    }
   }, []);
 
   React.useEffect(() => {
@@ -492,7 +574,7 @@ export function QueryEditor({
         const parsedQuery = JSON.parse(data.queryJson ?? '{}');
         data.query = parsedQuery.query ?? { AND: [] };
         data.assignments = parsedQuery.assignments ?? [];
-        querySchema.parse(data.query);
+        conditionGroupSchema.parse(data.query);
         z.array(setConditionSchema).parse(data.assignments);
       } catch (error) {
         toast({
@@ -510,11 +592,20 @@ export function QueryEditor({
 
     if (onSave) {
       onSave(data)
-        .then(() => {
+        .then(async result => {
+          const createdId = result?.id;
           toast({
-            title: 'Query saved',
-            description: 'It will be available in a couple os seconds',
+            title: initialData?._id ? 'Query updated' : 'Query created',
+            description: createdId
+              ? `${data.name} is available at ${getEndpointPath(data.name)}.`
+              : `${data.name} has been saved.`,
           });
+          await workspace?.refreshQueries();
+          if (createdId && !initialData?._id) {
+            workspace?.setDirty(false);
+            router.push(`/database/queries/${createdId}`);
+            return;
+          }
           reset(getValues());
         })
         .catch(error => {
@@ -528,13 +619,31 @@ export function QueryEditor({
       toast({
         title: 'Query saved',
         description: (
-          <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-            <code className="text-white">{JSON.stringify(data, null, 2)}</code>
+          <pre className="mt-2 w-[340px] rounded-md bg-muted p-4">
+            <code>{JSON.stringify(data, null, 2)}</code>
           </pre>
         ),
       });
     }
   };
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isSaveShortcut =
+        (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's';
+      if (!isSaveShortcut) return;
+      event.preventDefault();
+      if (!isSubmitting && isDirty) {
+        const formEl = document.getElementById(
+          'query-editor-form'
+        ) as HTMLFormElement | null;
+        formEl?.requestSubmit();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isDirty, isSubmitting]);
 
   const handleInputModeChange = (mode: 'form' | 'json') => {
     if (mode === 'json' && inputMode === 'form') {
@@ -546,7 +655,10 @@ export function QueryEditor({
       try {
         const inputsJson = form.getValues('inputsJson');
         const parsedInputs = JSON.parse(inputsJson ?? '[]');
-        form.setValue('inputs', parsedInputs);
+        form.setValue('inputs', parsedInputs, {
+          shouldDirty: true,
+          shouldTouch: true,
+        });
       } catch (error) {
         toast({
           title: 'Invalid JSON',
@@ -587,8 +699,14 @@ export function QueryEditor({
         if (!Array.isArray(findConditions[firstKey])) {
           findConditions[firstKey] = [];
         }
-        form.setValue('query', findConditions);
-        form.setValue('assignments', parsedQuery.assignments || []);
+        form.setValue('query', findConditions, {
+          shouldDirty: true,
+          shouldTouch: true,
+        });
+        form.setValue('assignments', parsedQuery.assignments || [], {
+          shouldDirty: true,
+          shouldTouch: true,
+        });
       } catch (error) {
         toast({
           title: 'Invalid JSON',
@@ -601,22 +719,21 @@ export function QueryEditor({
     setQueryMode(mode);
   };
 
-  const countConditions = (group: any) => {
-    if (!group || !group[Object.keys(group)[0]]) return 0;
-    return group[Object.keys(group)[0]].reduce(
-      (count: number, condition: any) => {
-        // If it's a group, recursively count its conditions
-        if (
-          condition[Object.keys(condition)[0]] === 'AND' ||
-          condition[Object.keys(condition)[0]] === 'OR'
-        ) {
-          return count + countConditions(condition);
-        }
-        // Otherwise it's a single condition
-        return count + 1;
-      },
-      0
-    );
+  const countConditions = (group: unknown): number => {
+    if (!group || typeof group !== 'object') return 0;
+    const nested = group as { AND?: unknown[]; OR?: unknown[] };
+    const items = nested.AND ?? nested.OR;
+    if (!Array.isArray(items)) return 0;
+    return items.reduce((count: number, condition: unknown) => {
+      if (
+        condition &&
+        typeof condition === 'object' &&
+        ('AND' in condition || 'OR' in condition)
+      ) {
+        return count + countConditions(condition);
+      }
+      return count + 1;
+    }, 0);
   };
 
   const getConditionDescription = (condition: Comparison): string => {
@@ -709,14 +826,24 @@ export function QueryEditor({
             )}
           </div>
 
-          <Button
-            type="button"
-            variant="destructive"
-            size="icon"
-            onClick={() => removeFromGroup(parentPath, index)}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Remove condition"
+                  onClick={() => removeFromGroup(parentPath, index)}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Remove this condition from the draft. Save to persist.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
 
         <CollapsibleContent>
@@ -755,10 +882,13 @@ export function QueryEditor({
                         const n = Number(val);
                         field.onChange(n);
                         if (n !== ComparisonOperationEnum.EQUAL) {
-                          form.setValue(qp('comparisonField.like'), false);
+                          form.setValue(qp('comparisonField.like'), false, {
+                            shouldDirty: true,
+                          });
                           form.setValue(
                             qp('comparisonField.caseSensitiveLike'),
-                            false
+                            false,
+                            { shouldDirty: true }
                           );
                         }
                       }}
@@ -790,9 +920,17 @@ export function QueryEditor({
                 label={'Value Source'}
                 placeholder={'Select value source'}
                 fieldName={qp('comparisonField.type')}
+                description="Where the compared value comes from at request time."
                 options={valueSourceTypes.map(vs => ({
                   value: vs.value,
-                  label: vs.label,
+                  label: (
+                    <div className="flex flex-col">
+                      <span>{vs.label}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {vs.description}
+                      </span>
+                    </div>
+                  ),
                 }))}
               />
             </div>
@@ -828,7 +966,8 @@ export function QueryEditor({
                 <InputField
                   label={'Context Value'}
                   fieldName={qp('comparisonField.value')}
-                  placeholder={'e.g. user.id, currentDate'}
+                  placeholder={'e.g. user._id'}
+                  info="Request context path, such as user._id. Resolved when the endpoint runs."
                 />
               </div>
             )}
@@ -840,25 +979,24 @@ export function QueryEditor({
                   name={qp('comparisonField.like')}
                   control={form.control}
                   render={({ field }) => (
-                    <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormItem className="flex flex-row items-start gap-3">
                       <FormControl>
-                        <Input
-                          type="checkbox"
-                          className="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                        <Checkbox
                           checked={Boolean(field.value)}
-                          onChange={e => {
-                            const checked = e.target.checked;
-                            field.onChange(checked);
-                            if (!checked) {
+                          onCheckedChange={checked => {
+                            const isChecked = Boolean(checked);
+                            field.onChange(isChecked);
+                            if (!isChecked) {
                               form.setValue(
                                 qp('comparisonField.caseSensitiveLike'),
-                                false
+                                false,
+                                { shouldDirty: true }
                               );
                             }
                           }}
                         />
                       </FormControl>
-                      <div className="space-y-1 leading-none">
+                      <div className="flex flex-col gap-1 leading-none">
                         <FormLabel className="font-normal">
                           Like (pattern match)
                         </FormLabel>
@@ -870,16 +1008,30 @@ export function QueryEditor({
                   )}
                 />
                 {Boolean(form.watch(qp('comparisonField.like'))) && (
-                  <InputField
-                    type="checkbox"
-                    label="Case sensitive"
-                    fieldName={qp('comparisonField.caseSensitiveLike')}
-                    description="When off, matching is case-insensitive (e.g. ILIKE on PostgreSQL)."
-                    classNames={{
-                      formItem: 'flex flex-row items-center space-x-2',
-                      input:
-                        'h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary',
-                    }}
+                  <Controller
+                    name={qp('comparisonField.caseSensitiveLike')}
+                    control={form.control}
+                    render={({ field }) => (
+                      <FormItem className="flex flex-row items-center gap-3">
+                        <FormControl>
+                          <Checkbox
+                            checked={Boolean(field.value)}
+                            onCheckedChange={checked =>
+                              field.onChange(Boolean(checked))
+                            }
+                          />
+                        </FormControl>
+                        <div className="flex flex-col gap-1 leading-none">
+                          <FormLabel className="font-normal">
+                            Case sensitive
+                          </FormLabel>
+                          <FormDescription className="text-xs">
+                            When off, matching is case-insensitive (e.g. ILIKE
+                            on PostgreSQL).
+                          </FormDescription>
+                        </div>
+                      </FormItem>
+                    )}
                   />
                 )}
               </div>
@@ -904,14 +1056,17 @@ export function QueryEditor({
       (form.watch(`${path}.${groupType}` as QueryFormPath) as unknown[]) || [];
     return (
       <div
-        className={`border rounded-md p-4 mb-4 ${groupType === 'AND' ? 'border-blue-200' : 'border-amber-200'}`}
+        className={cn(
+          'mb-4 rounded-md border p-4',
+          groupType === 'AND' ? 'border-primary/30' : 'border-border'
+        )}
       >
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center space-x-2">
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
             {groupType === 'AND' ? (
-              <LogicalAnd className="h-5 w-5 text-blue-500" />
+              <LogicalAnd className="h-5 w-5 text-primary" />
             ) : (
-              <LogicalOr className="h-5 w-5 text-amber-500" />
+              <LogicalOr className="h-5 w-5 text-muted-foreground" />
             )}
             <SelectField
               label={''}
@@ -921,18 +1076,14 @@ export function QueryEditor({
                   : 'OR'
               }
               onValueChange={val => {
-                const current = form.watch(path as keyof QueryFormValues);
-                // @ts-ignore
+                const current = form.watch(path as keyof QueryFormValues) as {
+                  AND?: unknown;
+                  OR?: unknown;
+                };
                 if (current['AND']) {
-                  form.setValue(path as keyof QueryFormValues, {
-                    // @ts-ignore
-                    [val]: current['AND'],
-                  });
+                  setDirtyValue(path, { [val]: current['AND'] });
                 } else {
-                  form.setValue(path as keyof QueryFormValues, {
-                    // @ts-ignore
-                    [val]: current['OR'],
-                  });
+                  setDirtyValue(path, { [val]: current['OR'] });
                 }
               }}
               options={[
@@ -942,21 +1093,14 @@ export function QueryEditor({
             />
 
             {isNested && (
-              <Badge
-                variant={groupType === 'AND' ? 'default' : 'outline'}
-                className={
-                  groupType === 'OR'
-                    ? 'bg-amber-100 text-amber-800 border-amber-300'
-                    : ''
-                }
-              >
-                {countConditions(group)} condition
-                {countConditions(group) !== 1 ? 's' : ''}
+              <Badge variant={groupType === 'AND' ? 'secondary' : 'outline'}>
+                {countConditions(groupRoot)} condition
+                {countConditions(groupRoot) !== 1 ? 's' : ''}
               </Badge>
             )}
           </div>
 
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center gap-2">
             <Button
               type="button"
               variant="outline"
@@ -986,35 +1130,44 @@ export function QueryEditor({
                   groupType === 'AND' ? 'OR' : 'AND'
                 )
               }
-              className={
-                groupType === 'AND' ? 'text-amber-600' : 'text-blue-600'
-              }
             >
               <Plus className="mr-2 h-4 w-4" />
               Add {groupType === 'AND' ? 'OR' : 'AND'} Group
             </Button>
 
             {isNested && (
-              <Button
-                type="button"
-                variant="destructive"
-                size="icon"
-                onClick={() => {
-                  // Extract parent path and index from the current path
-                  const pathParts = path.split('.');
-                  const index = Number.parseInt(pathParts.pop() ?? '0');
-                  const parentPath = pathParts.join('.');
-                  removeFromGroup(parentPath, index);
-                }}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Remove group"
+                      onClick={() => {
+                        const pathParts = path.split('.');
+                        const index = Number.parseInt(pathParts.pop() ?? '0');
+                        const parentPath = pathParts.join('.');
+                        removeFromGroup(parentPath, index);
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Remove this group from the draft. Save to persist.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
           </div>
         </div>
 
         <div
-          className={`pl-4 border-l-2 ${groupType === 'AND' ? 'border-blue-200' : 'border-amber-200'}`}
+          className={cn(
+            'border-l-2 pl-4',
+            groupType === 'AND' ? 'border-primary/30' : 'border-border'
+          )}
         >
           {conditions.length === 0 ? (
             <div className="flex items-center justify-center p-6 bg-muted/20 rounded-md">
@@ -1071,14 +1224,24 @@ export function QueryEditor({
             )}
           </div>
 
-          <Button
-            type="button"
-            variant="destructive"
-            size="icon"
-            onClick={() => removeSetCondition(index)}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Remove set value"
+                  onClick={() => removeSetCondition(index)}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Remove this assignment from the draft. Save to persist.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
 
         <CollapsibleContent>
@@ -1118,8 +1281,16 @@ export function QueryEditor({
               <SelectField
                 label={'Value Source'}
                 fieldName={`assignments.${index}.assignmentField.type`}
+                description="Where the assigned value comes from at request time."
                 options={valueSourceTypes.map(vs => ({
-                  label: vs.label,
+                  label: (
+                    <div className="flex flex-col">
+                      <span>{vs.label}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {vs.description}
+                      </span>
+                    </div>
+                  ),
                   value: vs.value,
                 }))}
               />
@@ -1156,7 +1327,8 @@ export function QueryEditor({
                 <InputField
                   label={'Context Value'}
                   fieldName={`assignments.${index}.assignmentField.value`}
-                  placeholder={'e.g. user.id, currentDate'}
+                  placeholder={'e.g. user._id'}
+                  info="Request context path, such as user._id. Resolved when the endpoint runs."
                 />
               </div>
             )}
@@ -1166,766 +1338,861 @@ export function QueryEditor({
     );
   };
 
+  const operationMeta = getOperationMeta(operation);
+  const endpointPath = getEndpointPath(queryName);
+
+  const handleCopyPath = async () => {
+    try {
+      await navigator.clipboard.writeText(endpointPath);
+      setCopiedPath(true);
+      window.setTimeout(() => setCopiedPath(false), 1500);
+    } catch {
+      toast({
+        title: 'Copy failed',
+        description: 'Could not copy the endpoint path.',
+        variant: 'destructive',
+      });
+    }
+  };
+
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-2">
-            {onBack && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                onClick={onBack}
-              >
-                <ArrowLeft className="h-4 w-4" />
-              </Button>
-            )}
-            <h2 className="text-2xl font-bold">
-              {initialData?._id ? 'Edit Query' : 'Create New Query'}
-            </h2>
-          </div>
-          <div className="flex items-center gap-2">
-            {onDelete && (
-              <>
+      <form
+        id="query-editor-form"
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex min-h-full flex-col"
+      >
+        <div className="sticky top-0 z-10 flex flex-col gap-3 border-b bg-background/95 px-6 py-3 backdrop-blur-sm">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-lg font-semibold text-balance">
+                  {initialData?._id
+                    ? queryName || 'Edit query'
+                    : 'Create query'}
+                </h2>
+                {isDirty && (
+                  <Badge variant="secondary" className="font-normal">
+                    Unsaved changes
+                  </Badge>
+                )}
+                <Badge variant="outline" className="font-mono font-normal">
+                  {operationMeta.method}
+                </Badge>
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-2">
+                <code className="truncate font-mono text-xs text-muted-foreground slashed-zero">
+                  {endpointPath}
+                </code>
+                <TooltipProvider delayDuration={300}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7"
+                        aria-label="Copy endpoint path"
+                        onClick={() => void handleCopyPath()}
+                      >
+                        {copiedPath ? (
+                          <Check className="size-3.5" />
+                        ) : (
+                          <Copy className="size-3.5" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Client API path for this custom endpoint
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {initialData?._id && workspace && (
                 <Button
                   type="button"
-                  variant="destructive"
-                  onClick={() => setDeleteDialogOpen(true)}
+                  variant="outline"
+                  onClick={() =>
+                    workspace.requestDelete(
+                      initialData._id as string,
+                      queryName || initialData.name || 'this query'
+                    )
+                  }
                 >
                   <Trash2 className="mr-2 h-4 w-4" />
                   Delete
                 </Button>
-                <AlertDialog
-                  open={deleteDialogOpen}
-                  onOpenChange={setDeleteDialogOpen}
-                >
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Delete custom query?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        This removes the custom endpoint from the platform. This
-                        action cannot be undone.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                        onClick={e => {
-                          e.preventDefault();
-                          void onDelete().catch((error: Error) => {
-                            toast({
-                              title: 'Error deleting query',
-                              description: error.message,
-                              variant: 'destructive',
-                            });
-                          });
-                        }}
-                      >
-                        Delete
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </>
-            )}
-            <Button
-              type="submit"
-              variant={isDirty ? 'default' : 'outline'}
-              disabled={!isDirty || isSubmitting}
-            >
-              <Save className="mr-2 h-4 w-4" />
-              Save Query
-            </Button>
+              )}
+              <Button
+                type="submit"
+                disabled={!isDirty || isSubmitting}
+                className="gap-2"
+              >
+                {isSubmitting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                {isSubmitting
+                  ? 'Saving…'
+                  : initialData?._id
+                    ? 'Save changes'
+                    : 'Create query'}
+                {!isSubmitting && isDirty && (
+                  <kbd className="ml-1 rounded border bg-primary-foreground/20 px-1.5 py-0.5 font-mono text-[10px]">
+                    {saveShortcutLabel}
+                  </kbd>
+                )}
+              </Button>
+            </div>
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Query Information</CardTitle>
-              <CardDescription>
-                Define the basic properties of your query
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <InputField
-                  label={'Query Name'}
-                  fieldName={'name'}
-                  placeholder="Enter query name"
-                />
-              </div>
+        <div className="flex flex-col gap-6 p-6">
+          {operation === OperationsEnum.DELETE && (
+            <Alert variant="destructive">
+              <AlertTitle>This endpoint deletes documents</AlertTitle>
+              <AlertDescription>
+                Runtime calls matching the find conditions will permanently
+                remove documents from{' '}
+                {form.watch('selectedSchemaName') || 'the selected model'}.
+              </AlertDescription>
+            </Alert>
+          )}
 
-              <div className="space-y-2">
-                <TextAreaField
-                  label={'Description'}
-                  fieldName={'endpointDescription'}
-                  placeholder="Describe what this query does"
-                  rows={3}
-                />
-              </div>
-
-              <FormField
-                control={form.control}
-                name="authentication"
-                render={({ field }) => (
-                  <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-                    <div className="space-y-0.5">
-                      <FormLabel
-                        htmlFor="query-authentication"
-                        className="text-base font-medium"
-                      >
-                        Requires Authentication
-                      </FormLabel>
-                      <FormDescription>
-                        When enabled, this query is only accessible to
-                        authenticated users.
-                      </FormDescription>
-                    </div>
-                    <FormControl>
-                      <Switch
-                        id="query-authentication"
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {operation === OperationsEnum.GET && (
-                <div className="space-y-3">
-                  <FormField
-                    control={form.control}
-                    name="paginated"
-                    render={({ field }) => (
-                      <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-                        <div className="space-y-0.5">
-                          <FormLabel
-                            htmlFor="query-paginated"
-                            className="text-base font-medium"
-                          >
-                            Paginated
-                          </FormLabel>
-                          <FormDescription>
-                            Expose skip and limit query parameters and return a
-                            document count with results.
-                          </FormDescription>
-                        </div>
-                        <FormControl>
-                          <Switch
-                            id="query-paginated"
-                            checked={field.value}
-                            onCheckedChange={field.onChange}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="sorted"
-                    render={({ field }) => (
-                      <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-                        <div className="space-y-0.5">
-                          <FormLabel
-                            htmlFor="query-sorted"
-                            className="text-base font-medium"
-                          >
-                            Sorted
-                          </FormLabel>
-                          <FormDescription>
-                            Allow clients to pass sort query parameters on GET
-                            requests.
-                          </FormDescription>
-                        </div>
-                        <FormControl>
-                          <Switch
-                            id="query-sorted"
-                            checked={field.value}
-                            onCheckedChange={field.onChange}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Query Information</CardTitle>
+                <CardDescription>
+                  Name, model, and runtime options for this endpoint
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <InputField
+                    label={'Query Name'}
+                    fieldName={'name'}
+                    placeholder="GetUsersByTeam"
+                    info="Becomes the Client API path: /database/function/{name}. Spaces are not allowed."
                   />
                 </div>
-              )}
 
-              <div className="space-y-2">
-                <SelectField
-                  label={'Operation'}
-                  placeholder="Select operation"
-                  disabled={!!initialData?._id}
-                  classNames={{
-                    selectTrigger:
-                      '[&>span>div]:flex-row [&>span>div]:items-center [&>span>div]:justify-start [&>span>div]:gap-2',
-                  }}
-                  options={operationTypes.map(op => ({
-                    value: op.value,
-                    label: (
-                      <div className="flex flex-col">
-                        <span>{op.label}</span>
-                        <span className="text-xs text-muted-foreground">
-                          {op.description}
-                        </span>
+                <div className="space-y-2">
+                  <TextAreaField
+                    label={'Description'}
+                    fieldName={'endpointDescription'}
+                    placeholder="Describe what this query does"
+                    rows={3}
+                  />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name="authentication"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
+                      <div className="space-y-0.5">
+                        <div className="flex items-center gap-1.5">
+                          <FormLabel
+                            htmlFor="query-authentication"
+                            className="text-base font-medium"
+                          >
+                            Requires Authentication
+                          </FormLabel>
+                          <QueryFieldHint content="When enabled, callers must send a user bearer token. Anonymous Client API requests are rejected." />
+                        </div>
+                        <FormDescription>
+                          When enabled, this query is only accessible to
+                          authenticated users.
+                        </FormDescription>
                       </div>
-                    ),
-                  }))}
-                  fieldName={'operation'}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="model">Model</Label>
-                <Dialog
-                  open={isModelDialogOpen}
-                  onOpenChange={setIsModelDialogOpen}
-                >
-                  <DialogTrigger asChild>
-                    <Button
-                      variant="outline"
-                      className="w-full justify-start"
-                      disabled={!!initialData?._id}
-                    >
-                      {form.watch('selectedSchemaName') || 'Select a model'}
-                    </Button>
-                  </DialogTrigger>
-                  <DialogContent className="sm:max-w-md">
-                    <DialogHeader>
-                      <DialogTitle>Select Model</DialogTitle>
-                    </DialogHeader>
-                    <div className="space-y-4">
-                      <div className="flex items-center space-x-2">
-                        <Search className="w-4 h-4 text-muted-foreground" />
-                        <Input
-                          placeholder="Search models..."
-                          value={modelSearchTerm}
-                          onChange={e => setModelSearchTerm(e.target.value)}
+                      <FormControl>
+                        <Switch
+                          id="query-authentication"
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
                         />
-                      </div>
-                      <ScrollArea className="h-[300px]">
-                        <div className="space-y-2">
-                          {filteredModels.map(model => (
-                            <Button
-                              key={model._id}
-                              variant="ghost"
-                              className="w-full justify-start text-left"
-                              onClick={() => {
-                                form.setValue('selectedSchema', model._id, {
-                                  shouldValidate: true,
-                                  shouldDirty: true,
-                                  shouldTouch: true,
-                                });
-                                form.setValue(
-                                  'selectedSchemaName',
-                                  model.name,
-                                  {
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {operation === OperationsEnum.GET && (
+                  <div className="space-y-3">
+                    <FormField
+                      control={form.control}
+                      name="paginated"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
+                          <div className="space-y-0.5">
+                            <div className="flex items-center gap-1.5">
+                              <FormLabel
+                                htmlFor="query-paginated"
+                                className="text-base font-medium"
+                              >
+                                Paginated
+                              </FormLabel>
+                              <QueryFieldHint content="Adds skip and limit query parameters and returns a document count with results." />
+                            </div>
+                            <FormDescription>
+                              Expose skip and limit query parameters and return
+                              a document count with results.
+                            </FormDescription>
+                          </div>
+                          <FormControl>
+                            <Switch
+                              id="query-paginated"
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="sorted"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
+                          <div className="space-y-0.5">
+                            <div className="flex items-center gap-1.5">
+                              <FormLabel
+                                htmlFor="query-sorted"
+                                className="text-base font-medium"
+                              >
+                                Sorted
+                              </FormLabel>
+                              <QueryFieldHint content="Allows clients to pass sort query parameters on GET requests." />
+                            </div>
+                            <FormDescription>
+                              Allow clients to pass sort query parameters on GET
+                              requests.
+                            </FormDescription>
+                          </div>
+                          <FormControl>
+                            <Switch
+                              id="query-sorted"
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-1">
+                    <span className="text-sm font-medium">Operation</span>
+                    <QueryFieldHint
+                      content={
+                        initialData?._id
+                          ? 'The HTTP method is part of the endpoint contract and cannot change after create.'
+                          : 'Maps to the HTTP method clients will call on /database/function/{name}.'
+                      }
+                    />
+                  </div>
+                  <SelectField
+                    label={'Operation'}
+                    placeholder="Select operation"
+                    disabled={!!initialData?._id}
+                    classNames={{
+                      label: 'sr-only',
+                      selectTrigger:
+                        '[&>span>div]:flex-row [&>span>div]:items-center [&>span>div]:justify-start [&>span>div]:gap-2',
+                    }}
+                    options={operationTypes.map(op => ({
+                      value: op.value,
+                      label: (
+                        <div className="flex flex-col">
+                          <span>
+                            {op.label} · {getOperationMeta(op.value).method}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {op.description}
+                          </span>
+                        </div>
+                      ),
+                    }))}
+                    fieldName={'operation'}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-1">
+                    <Label htmlFor="model">Model</Label>
+                    <QueryFieldHint
+                      content={
+                        initialData?._id
+                          ? 'The target schema is locked after create.'
+                          : 'The schema this endpoint reads or writes.'
+                      }
+                    />
+                  </div>
+                  <Dialog
+                    open={isModelDialogOpen}
+                    onOpenChange={setIsModelDialogOpen}
+                  >
+                    <DialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start"
+                        disabled={!!initialData?._id}
+                      >
+                        {form.watch('selectedSchemaName') || 'Select a model'}
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent className="sm:max-w-md">
+                      <DialogHeader>
+                        <DialogTitle>Select Model</DialogTitle>
+                      </DialogHeader>
+                      <div className="space-y-4">
+                        <div className="flex items-center space-x-2">
+                          <Search className="w-4 h-4 text-muted-foreground" />
+                          <Input
+                            placeholder="Search models..."
+                            value={modelSearchTerm}
+                            onChange={e => setModelSearchTerm(e.target.value)}
+                          />
+                        </div>
+                        <ScrollArea className="h-[300px]">
+                          <div className="flex flex-col gap-2">
+                            {modelsLoading && (
+                              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                                Loading models…
+                              </p>
+                            )}
+                            {!modelsLoading && filteredModels.length === 0 && (
+                              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                                No models match this operation and search.
+                              </p>
+                            )}
+                            {filteredModels.map(model => (
+                              <Button
+                                key={model._id}
+                                variant="ghost"
+                                className="w-full justify-start text-left"
+                                onClick={() => {
+                                  form.setValue('selectedSchema', model._id, {
                                     shouldValidate: true,
                                     shouldDirty: true,
                                     shouldTouch: true,
-                                  }
-                                );
-                                setIsModelDialogOpen(false);
-                              }}
-                            >
-                              <div className="flex flex-col">
-                                <span>{model.name}</span>
-                              </div>
-                            </Button>
-                          ))}
-                        </div>
-                      </ScrollArea>
-                    </div>
-                  </DialogContent>
-                </Dialog>
-                {form.formState.errors.selectedSchema && (
-                  <p className="text-sm text-destructive">
-                    {form.formState.errors.selectedSchema.message}
-                  </p>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Query Inputs</CardTitle>
-              <CardDescription>
-                Define the inputs for your query
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Tabs
-                value={inputMode}
-                onValueChange={value =>
-                  handleInputModeChange(value as 'form' | 'json')
-                }
-              >
-                <TabsList className="mb-4">
-                  <TabsTrigger value="form">
-                    <FormInput className="w-4 h-4 mr-2" />
-                    Form
-                  </TabsTrigger>
-                  <TabsTrigger value="json">
-                    <FileJson className="w-4 h-4 mr-2" />
-                    JSON
-                  </TabsTrigger>
-                </TabsList>
-
-                <TabsContent value="form" className="space-y-4">
-                  {fields.map((field, index) => (
-                    <Collapsible
-                      key={field.id}
-                      className="border rounded-md overflow-hidden"
-                    >
-                      <div className="flex items-center justify-between p-3 bg-muted/30 cursor-pointer">
-                        <CollapsibleTrigger className="flex items-center space-x-2 grow justify-between text-left cursor-pointer mr-2">
-                          <div
-                            className={
-                              'flex flex-row space-x-2 text-left items-center'
-                            }
-                          >
-                            <ChevronDown className="h-4 w-4 shrink-0 transition-transform ui-open:rotate-180" />
-                            <span className="font-medium truncate">
-                              {form.watch(`inputs.${index}.name`) ||
-                                `Input #${index + 1}`}
-                            </span>
+                                  });
+                                  form.setValue(
+                                    'selectedSchemaName',
+                                    model.name,
+                                    {
+                                      shouldValidate: true,
+                                      shouldDirty: true,
+                                      shouldTouch: true,
+                                    }
+                                  );
+                                  setIsModelDialogOpen(false);
+                                }}
+                              >
+                                <div className="flex flex-col">
+                                  <span>{model.name}</span>
+                                </div>
+                              </Button>
+                            ))}
                           </div>
-                          {form.watch(`inputs.${index}.name`) && (
-                            <div className="flex items-center space-x-2">
-                              <div className="flex items-center space-x-1">
-                                {getTypeIcon(
-                                  ValueTypeEnum[
-                                    form.watch(
-                                      `inputs.${index}.type`
-                                    ) as keyof typeof ValueTypeEnum
-                                  ]
-                                )}
-                                <Badge variant="outline" className="text-xs">
-                                  {form.watch(`inputs.${index}.type`)}
-                                  {form.watch(`inputs.${index}.array`) && '[]'}
-                                </Badge>
-                              </div>
+                        </ScrollArea>
+                      </div>
+                    </DialogContent>
+                  </Dialog>
+                  {form.formState.errors.selectedSchema && (
+                    <p className="text-sm text-destructive">
+                      {form.formState.errors.selectedSchema.message}
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
 
-                              <div className="flex items-center space-x-1">
-                                {getPlacementIcon(
-                                  form.watch(
-                                    `inputs.${index}.location`
-                                  ) as LocationEnum
-                                )}
-                                <Badge variant="secondary" className="text-xs">
-                                  {getPlacementName(
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-1.5">
+                  Query Inputs
+                  <QueryFieldHint content="Inputs become request parameters. Path values are required URL segments; query and body values are optional unless marked required." />
+                </CardTitle>
+                <CardDescription>
+                  Parameters callers pass when invoking this endpoint
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Tabs
+                  value={inputMode}
+                  onValueChange={value =>
+                    handleInputModeChange(value as 'form' | 'json')
+                  }
+                >
+                  <div className="mb-4 flex items-center gap-2">
+                    <TabsList>
+                      <TabsTrigger value="form">
+                        <FormInput className="mr-2 h-4 w-4" />
+                        Form
+                      </TabsTrigger>
+                      <TabsTrigger value="json">
+                        <FileJson className="mr-2 h-4 w-4" />
+                        JSON
+                      </TabsTrigger>
+                    </TabsList>
+                    <QueryFieldHint content="JSON mode edits the raw input contract. Validate before saving." />
+                  </div>
+
+                  <TabsContent value="form" className="space-y-4">
+                    {fields.map((field, index) => (
+                      <Collapsible
+                        key={field.id}
+                        className="border rounded-md overflow-hidden"
+                      >
+                        <div className="flex items-center justify-between p-3 bg-muted/30 cursor-pointer">
+                          <CollapsibleTrigger className="flex items-center space-x-2 grow justify-between text-left cursor-pointer mr-2">
+                            <div
+                              className={
+                                'flex flex-row space-x-2 text-left items-center'
+                              }
+                            >
+                              <ChevronDown className="h-4 w-4 shrink-0 transition-transform ui-open:rotate-180" />
+                              <span className="font-medium truncate">
+                                {form.watch(`inputs.${index}.name`) ||
+                                  `Input #${index + 1}`}
+                              </span>
+                            </div>
+                            {form.watch(`inputs.${index}.name`) && (
+                              <div className="flex items-center space-x-2">
+                                <div className="flex items-center space-x-1">
+                                  {getTypeIcon(
+                                    ValueTypeEnum[
+                                      form.watch(
+                                        `inputs.${index}.type`
+                                      ) as keyof typeof ValueTypeEnum
+                                    ]
+                                  )}
+                                  <Badge variant="outline" className="text-xs">
+                                    {form.watch(`inputs.${index}.type`)}
+                                    {form.watch(`inputs.${index}.array`) &&
+                                      '[]'}
+                                  </Badge>
+                                </div>
+
+                                <div className="flex items-center space-x-1">
+                                  {getPlacementIcon(
                                     form.watch(
                                       `inputs.${index}.location`
                                     ) as LocationEnum
                                   )}
-                                </Badge>
+                                  <Badge
+                                    variant="secondary"
+                                    className="text-xs"
+                                  >
+                                    {getPlacementName(
+                                      form.watch(
+                                        `inputs.${index}.location`
+                                      ) as LocationEnum
+                                    )}
+                                  </Badge>
+                                </div>
+
+                                {form.watch(`inputs.${index}.optional`) && (
+                                  <Badge variant="outline" className="text-xs">
+                                    Optional
+                                  </Badge>
+                                )}
+                              </div>
+                            )}
+                          </CollapsibleTrigger>
+                          <TooltipProvider delayDuration={300}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  aria-label={`Remove input ${form.watch(`inputs.${index}.name`) || index + 1}`}
+                                  onClick={() => remove(index)}
+                                >
+                                  <Trash2 className="h-4 w-4 text-destructive" />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                Remove this input from the draft. Save to
+                                persist.
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </div>
+
+                        <CollapsibleContent>
+                          <div className="p-4 space-y-4">
+                            <div className="space-y-2">
+                              <InputField
+                                label={'Name'}
+                                fieldName={`inputs.${index}.name`}
+                                placeholder={'e.g. id, name, filter'}
+                              />
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-4">
+                              <div className="space-y-2">
+                                <SelectField
+                                  label={'Type'}
+                                  fieldName={`inputs.${index}.type`}
+                                  placeholder="Select type"
+                                  options={inputTypes.map(type => ({
+                                    value: type.value,
+                                    label: (
+                                      <div className="flex items-center space-x-2">
+                                        {getTypeIcon(type.value)}
+                                        <span>{type.label}</span>
+                                      </div>
+                                    ),
+                                  }))}
+                                />
                               </div>
 
-                              {form.watch(`inputs.${index}.optional`) && (
-                                <Badge
-                                  variant="outline"
-                                  className="bg-yellow-100 text-yellow-800 border-yellow-300 text-xs"
-                                >
-                                  Optional
-                                </Badge>
-                              )}
-                            </div>
-                          )}
-                        </CollapsibleTrigger>
-                        <Button
-                          type="button"
-                          variant="destructive"
-                          size="icon"
-                          onClick={() => remove(index)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-
-                      <CollapsibleContent>
-                        <div className="p-4 space-y-4">
-                          <div className="space-y-2">
-                            <InputField
-                              label={'Name'}
-                              fieldName={`inputs.${index}.name`}
-                              placeholder={'e.g. id, name, filter'}
-                            />
-                          </div>
-
-                          <div className="grid grid-cols-2 gap-4">
-                            <div className="space-y-2">
-                              <SelectField
-                                label={'Type'}
-                                fieldName={`inputs.${index}.type`}
-                                placeholder="Select type"
-                                options={inputTypes.map(type => ({
-                                  value: type.value,
-                                  label: (
-                                    <div className="flex items-center space-x-2">
-                                      {getTypeIcon(type.value)}
-                                      <span>{type.label}</span>
-                                    </div>
-                                  ),
-                                }))}
-                              />
-                            </div>
-
-                            <div className="space-y-2">
-                              <SelectField
-                                label={'Placement'}
-                                fieldName={`inputs.${index}.location`}
-                                placeholder="Select placement"
-                                options={placementTypes.map(place => ({
-                                  value: place.value,
-                                  label: (
-                                    <div className="flex items-center space-x-2">
-                                      {getPlacementIcon(place.value)}
-                                      <div className="flex flex-col">
-                                        <span>{place.label}</span>
-                                        <span className="text-xs text-muted-foreground">
-                                          {place.description}
-                                        </span>
+                              <div className="space-y-2">
+                                <SelectField
+                                  label={'Placement'}
+                                  fieldName={`inputs.${index}.location`}
+                                  placeholder="Select placement"
+                                  options={placementTypes.map(place => ({
+                                    value: place.value,
+                                    label: (
+                                      <div className="flex items-center gap-2">
+                                        {getPlacementIcon(place.value)}
+                                        <div className="flex flex-col">
+                                          <span>{place.label}</span>
+                                          <span className="text-xs text-muted-foreground">
+                                            {place.description}
+                                          </span>
+                                        </div>
                                       </div>
+                                    ),
+                                  }))}
+                                />
+                                {form.watch(`inputs.${index}.location`) ===
+                                  LocationEnum.BODY &&
+                                  [
+                                    OperationsEnum.GET,
+                                    OperationsEnum.DELETE,
+                                  ].includes(operation) && (
+                                    <p className="text-xs text-destructive">
+                                      Body parameters are not allowed for{' '}
+                                      Find/Delete operations
+                                    </p>
+                                  )}
+                              </div>
+                            </div>
+
+                            <div className="flex flex-wrap gap-6">
+                              <FormField
+                                control={form.control}
+                                name={`inputs.${index}.optional`}
+                                render={({ field }) => (
+                                  <FormItem className="flex flex-row items-center gap-2">
+                                    <FormControl>
+                                      <Checkbox
+                                        id={`inputs.${index}.optional`}
+                                        checked={Boolean(field.value)}
+                                        disabled={
+                                          form.watch(
+                                            `inputs.${index}.location`
+                                          ) === LocationEnum.URL
+                                        }
+                                        onCheckedChange={checked =>
+                                          field.onChange(Boolean(checked))
+                                        }
+                                      />
+                                    </FormControl>
+                                    <div className="flex items-center gap-1">
+                                      <FormLabel
+                                        htmlFor={`inputs.${index}.optional`}
+                                        className="font-normal"
+                                      >
+                                        Optional
+                                      </FormLabel>
+                                      <QueryFieldHint content="Path parameters cannot be optional. Query and body inputs can be omitted by the client." />
                                     </div>
-                                  ),
-                                }))}
-                              />
-                              {form.watch(`inputs.${index}.location`) ===
-                                LocationEnum.BODY &&
-                                [
-                                  OperationsEnum.GET,
-                                  OperationsEnum.DELETE,
-                                ].includes(operation) && (
-                                  <p className="text-xs text-destructive">
-                                    Body parameters are not allowed for{' '}
-                                    Find/Delete operations
-                                  </p>
+                                  </FormItem>
                                 )}
-                            </div>
-                          </div>
-
-                          <div className="flex flex-wrap gap-4">
-                            <div className="flex items-center space-x-2">
-                              <InputField
-                                type="checkbox"
-                                id={`inputs.${index}.optional`}
-                                label={'Optional'}
-                                fieldName={`inputs.${index}.optional`}
-                                disabled={
-                                  form.watch(`inputs.${index}.location`) ===
-                                  LocationEnum.URL
-                                }
-                                classNames={{
-                                  formItem:
-                                    'flex flex-row items-center space-x-2',
-                                  input:
-                                    'h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary',
-                                  label:
-                                    form.watch(`inputs.${index}.location`) ===
-                                    LocationEnum.URL
-                                      ? 'text-muted-foreground'
-                                      : '',
-                                }}
                               />
-                            </div>
-
-                            <div className="flex items-center space-x-2">
-                              <InputField
-                                type="checkbox"
-                                id={`inputs.${index}.array`}
-                                disabled={
-                                  form.watch(`inputs.${index}.location`) ===
-                                  LocationEnum.URL
-                                }
-                                classNames={{
-                                  formItem:
-                                    'flex flex-row items-center space-x-2',
-                                  input:
-                                    'h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary',
-                                  label:
-                                    form.watch(`inputs.${index}.location`) ===
-                                    LocationEnum.URL
-                                      ? 'text-muted-foreground'
-                                      : '',
-                                }}
-                                fieldName={`inputs.${index}.array`}
-                                label={'Is Array'}
+                              <FormField
+                                control={form.control}
+                                name={`inputs.${index}.array`}
+                                render={({ field }) => (
+                                  <FormItem className="flex flex-row items-center gap-2">
+                                    <FormControl>
+                                      <Checkbox
+                                        id={`inputs.${index}.array`}
+                                        checked={Boolean(field.value)}
+                                        disabled={
+                                          form.watch(
+                                            `inputs.${index}.location`
+                                          ) === LocationEnum.URL
+                                        }
+                                        onCheckedChange={checked =>
+                                          field.onChange(Boolean(checked))
+                                        }
+                                      />
+                                    </FormControl>
+                                    <div className="flex items-center gap-1">
+                                      <FormLabel
+                                        htmlFor={`inputs.${index}.array`}
+                                        className="font-normal"
+                                      >
+                                        Is array
+                                      </FormLabel>
+                                      <QueryFieldHint content="Accept multiple values. Path parameters cannot be arrays." />
+                                    </div>
+                                  </FormItem>
+                                )}
                               />
                             </div>
                           </div>
-                        </div>
-                      </CollapsibleContent>
-                    </Collapsible>
-                  ))}
+                        </CollapsibleContent>
+                      </Collapsible>
+                    ))}
 
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() =>
+                        append({
+                          name: '',
+                          type: ValueTypeEnum.STRING,
+                          location: LocationEnum.QUERY,
+                          optional: false,
+                          array: false,
+                        })
+                      }
+                      className="w-full"
+                    >
+                      <Plus className="mr-2 h-4 w-4" />
+                      Add Input
+                    </Button>
+                  </TabsContent>
+
+                  <TabsContent value="json">
+                    <div className="space-y-2">
+                      <TextAreaField
+                        label={'Inputs JSON'}
+                        fieldName={'inputsJson'}
+                        rows={15}
+                        placeholder={INPUTS_JSON_PLACEHOLDER}
+                        className="font-mono slashed-zero"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Array of inputs. `location` is 0 body, 1 query, 2 path.
+                        `type` uses String, Number, Boolean, Date, ObjectId, or
+                        JSON.
+                      </p>
+                    </div>
+                  </TabsContent>
+                </Tabs>
+              </CardContent>
+              <CardFooter className="flex justify-between">
+                <div className="text-sm text-muted-foreground">
+                  {fields.length} input{fields.length !== 1 ? 's' : ''} defined
+                </div>
+                {inputMode === 'json' && (
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={() =>
-                      append({
-                        name: '',
-                        type: ValueTypeEnum.STRING,
-                        location: LocationEnum.QUERY,
-                        optional: false,
-                        array: false,
-                      })
-                    }
-                    className="w-full"
-                  >
-                    <Plus className="mr-2 h-4 w-4" />
-                    Add Input
-                  </Button>
-                </TabsContent>
-
-                <TabsContent value="json">
-                  <div className="space-y-2">
-                    <TextAreaField
-                      label={'Inputs JSON'}
-                      fieldName={'inputsJson'}
-                      rows={15}
-                      placeholder={`[
-                      {
-                        "name": "id",
-                        "type": "string",
-                        "location": 0,
-                        "optional": false,
-                        "array": false
+                    onClick={() => {
+                      try {
+                        const inputsJson = form.getValues('inputsJson');
+                        const parsed = JSON.parse(inputsJson ?? '[]');
+                        inputsSchema.parse(parsed);
+                        toast({
+                          title: 'Valid JSON',
+                          description: 'Your JSON syntax is valid',
+                        });
+                      } catch (error) {
+                        toast({
+                          title: 'Invalid JSON',
+                          description: 'Please check your JSON syntax',
+                          variant: 'destructive',
+                        });
                       }
-                    ]`}
-                      className="font-mono"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Define complex input types using JSON format
-                    </p>
-                  </div>
-                </TabsContent>
-              </Tabs>
-            </CardContent>
-            <CardFooter className="flex justify-between">
-              <div className="text-sm text-muted-foreground">
-                {fields.length} input{fields.length !== 1 ? 's' : ''} defined
-              </div>
-              {inputMode === 'json' && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => {
-                    try {
-                      const inputsJson = form.getValues('inputsJson');
-                      const parsed = JSON.parse(inputsJson ?? '[]');
-                      inputsSchema.parse(parsed);
-                      toast({
-                        title: 'Valid JSON',
-                        description: 'Your JSON syntax is valid',
-                      });
-                    } catch (error) {
-                      toast({
-                        title: 'Invalid JSON',
-                        description: 'Please check your JSON syntax',
-                        variant: 'destructive',
-                      });
-                    }
-                  }}
+                    }}
+                  >
+                    <Code className="mr-2 h-4 w-4" />
+                    Validate JSON
+                  </Button>
+                )}
+              </CardFooter>
+            </Card>
+          </div>
+
+          {form.watch('selectedSchema') && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-1.5">
+                  Query Definition
+                  <QueryFieldHint content="Find conditions filter documents. Set values write fields on Create, Update, and Patch." />
+                </CardTitle>
+                <CardDescription>
+                  Conditions and assignments executed by this endpoint
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Tabs
+                  value={queryMode}
+                  onValueChange={value =>
+                    handleQueryModeChange(value as 'form' | 'json')
+                  }
                 >
-                  <Code className="mr-2 h-4 w-4" />
-                  Validate JSON
-                </Button>
-              )}
-            </CardFooter>
-          </Card>
-        </div>
+                  <div className="mb-4 flex items-center gap-2">
+                    <TabsList>
+                      <TabsTrigger value="form">
+                        <Filter className="mr-2 h-4 w-4" />
+                        Form
+                      </TabsTrigger>
+                      <TabsTrigger value="json">
+                        <FileJson className="mr-2 h-4 w-4" />
+                        JSON
+                      </TabsTrigger>
+                    </TabsList>
+                    <QueryFieldHint content="JSON mode edits find conditions and assignments as a single document. Validate before saving." />
+                  </div>
 
-        {form.watch('selectedSchema') && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Query Definition</CardTitle>
-              <CardDescription>Define how your query will work</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Tabs
-                value={queryMode}
-                onValueChange={value =>
-                  handleQueryModeChange(value as 'form' | 'json')
-                }
-              >
-                <TabsList className="mb-4">
-                  <TabsTrigger value="form">
-                    <Filter className="w-4 h-4 mr-2" />
-                    Form
-                  </TabsTrigger>
-                  <TabsTrigger value="json">
-                    <FileJson className="w-4 h-4 mr-2" />
-                    JSON
-                  </TabsTrigger>
-                </TabsList>
+                  <TabsContent value="form" className="space-y-6">
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <h3 className="flex items-center gap-1.5 text-lg font-medium">
+                          <Filter className="h-5 w-5" />
+                          Find Conditions
+                          <QueryFieldHint content="Documents must match this group. AND requires every condition; OR requires any condition." />
+                        </h3>
+                      </div>
 
-                <TabsContent value="form" className="space-y-6">
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <h3 className="text-lg font-medium flex items-center">
-                        <Filter className="w-5 h-5 mr-2" />
-                        Find Conditions
-                      </h3>
+                      {renderConditionGroup('query')}
                     </div>
 
-                    {renderConditionGroup('query')}
-                  </div>
+                    {supportsSetConditions && (
+                      <>
+                        <Separator />
+                        <div className="space-y-4">
+                          <div className="flex items-center justify-between">
+                            <h3 className="flex items-center gap-1.5 text-lg font-medium">
+                              <Settings className="h-5 w-5" />
+                              Set Values
+                              <QueryFieldHint content="Fields written when this Create, Update, or Patch endpoint runs." />
+                            </h3>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                appendSetCondition({
+                                  schemaField: '',
+                                  action: AssignmentActionEnum.ASSIGN,
+                                  assignmentField: {
+                                    type: ValueSourceTypeEnum.INPUT,
+                                    value: '',
+                                  },
+                                })
+                              }
+                            >
+                              <Plus className="mr-2 h-4 w-4" />
+                              Add Set Value
+                            </Button>
+                          </div>
 
-                  {supportsSetConditions && (
-                    <>
-                      <Separator />
-                      <div className="space-y-4">
-                        <div className="flex items-center justify-between">
-                          <h3 className="text-lg font-medium flex items-center">
-                            <Settings className="w-5 h-5 mr-2" />
-                            Set Values
-                          </h3>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() =>
-                              appendSetCondition({
-                                schemaField: '',
-                                action: AssignmentActionEnum.ASSIGN,
-                                assignmentField: {
-                                  type: ValueSourceTypeEnum.INPUT,
-                                  value: '',
-                                },
-                              })
-                            }
-                          >
-                            <Plus className="mr-2 h-4 w-4" />
-                            Add Set Value
-                          </Button>
-                        </div>
-
-                        {setConditions.length === 0 ? (
-                          <div className="flex items-center justify-center p-6 border rounded-md bg-muted/20">
-                            <div className="text-center text-muted-foreground">
-                              <Settings className="w-10 h-10 mx-auto mb-2 opacity-20" />
-                              <p>No set values defined</p>
-                              <p className="text-sm">
-                                Add values to set in your {operation} operation
-                              </p>
+                          {setConditions.length === 0 ? (
+                            <div className="flex items-center justify-center p-6 border rounded-md bg-muted/20">
+                              <div className="text-center text-muted-foreground">
+                                <Settings className="w-10 h-10 mx-auto mb-2 opacity-20" />
+                                <p>No set values defined</p>
+                                <p className="text-sm">
+                                  Add values to set in your{' '}
+                                  {operationMeta.label} operation
+                                </p>
+                              </div>
                             </div>
-                          </div>
-                        ) : (
-                          <div className="space-y-2">
-                            {setConditions.map((condition, index) =>
-                              renderSetCondition(condition, index)
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </>
-                  )}
-                </TabsContent>
+                          ) : (
+                            <div className="space-y-2">
+                              {setConditions.map((condition, index) =>
+                                renderSetCondition(condition, index)
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </TabsContent>
 
-                <TabsContent value="json">
-                  <div className="space-y-2">
-                    <TextAreaField
-                      label={'Query JSON'}
-                      fieldName={'queryJson'}
-                      rows={15}
-                      className="font-mono"
-                      placeholder={`{
-  "query": {
-    "AND": [
-      {
-        "field": "name",
-        "operation": "eq",
-        "valueSource": "input",
-        "inputName": "name"
-      },
-      {
-        ""OR": [
-          {
-            "field": "age",
-            "operation": "gt",
-            "valueSource": "custom",
-            "customValue": "18"
-          },
-          {
-            "field": "isVerified",
-            "operation": "eq",
-            "valueSource": "custom",
-            "customValue": "true"
-          }
-        ]
-      }
-    ]
-  },
-  "assignment": [
-    {
-      "schemaField": "status",
-       "action": 0,
-      "assignmentField": {
-        "type":0,
-        "value": ""
-       },
-    }
-  ]
-}`}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Define your query conditions using JSON format
-                    </p>
-                  </div>
-                </TabsContent>
-              </Tabs>
-            </CardContent>
-            <CardFooter className="flex justify-between">
-              <div className="text-sm text-muted-foreground">
-                {countConditions(form.watch('query'))} find condition
-                {countConditions(form.watch('query')) !== 1 ? 's' : ''} and
-                {supportsSetConditions
-                  ? ` ${setConditions.length} set value${setConditions.length !== 1 ? 's' : ''}`
-                  : ' no set values'}{' '}
-                defined
-              </div>
-              {queryMode === 'json' && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => {
-                    try {
-                      const queryJson = form.getValues('queryJson');
-                      const parsed = JSON.parse(queryJson ?? '{}');
-                      if (parsed.query) {
-                        conditionGroupSchema.parse(parsed);
-                      }
-                      if (parsed.assignments) {
-                        z.array(setConditionSchema).parse(parsed.assignments);
-                      }
+                  <TabsContent value="json">
+                    <div className="space-y-2">
+                      <TextAreaField
+                        label={'Query JSON'}
+                        fieldName={'queryJson'}
+                        rows={15}
+                        className="font-mono slashed-zero"
+                        placeholder={QUERY_JSON_PLACEHOLDER}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Object with `query` (AND/OR groups) and `assignments`.
+                        Comparison `operation` and assignment `action` are
+                        numeric enums.
+                      </p>
+                    </div>
+                  </TabsContent>
+                </Tabs>
+              </CardContent>
+              <CardFooter className="flex justify-between">
+                <div className="text-sm text-muted-foreground">
+                  {countConditions(form.watch('query'))} find condition
+                  {countConditions(form.watch('query')) !== 1 ? 's' : ''} and
+                  {supportsSetConditions
+                    ? ` ${setConditions.length} set value${setConditions.length !== 1 ? 's' : ''}`
+                    : ' no set values'}{' '}
+                  defined
+                </div>
+                {queryMode === 'json' && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      try {
+                        const queryJson = form.getValues('queryJson');
+                        const parsed = JSON.parse(queryJson ?? '{}');
+                        if (parsed.query) {
+                          conditionGroupSchema.parse(parsed.query);
+                        }
+                        if (parsed.assignments) {
+                          z.array(setConditionSchema).parse(parsed.assignments);
+                        }
 
-                      toast({
-                        title: 'Valid JSON',
-                        description: 'Your JSON syntax is valid',
-                      });
-                    } catch (error) {
-                      toast({
-                        title: 'Invalid JSON',
-                        description: 'Please check your JSON syntax',
-                        variant: 'destructive',
-                      });
-                    }
-                  }}
-                >
-                  <Code className="mr-2 h-4 w-4" />
-                  Validate JSON
-                </Button>
-              )}
-            </CardFooter>
-          </Card>
-        )}
+                        toast({
+                          title: 'Valid JSON',
+                          description: 'Your JSON syntax is valid',
+                        });
+                      } catch (error) {
+                        toast({
+                          title: 'Invalid JSON',
+                          description: 'Please check your JSON syntax',
+                          variant: 'destructive',
+                        });
+                      }
+                    }}
+                  >
+                    <Code className="mr-2 h-4 w-4" />
+                    Validate JSON
+                  </Button>
+                )}
+              </CardFooter>
+            </Card>
+          )}
+        </div>
       </form>
     </Form>
   );

--- a/src/components/database/queries/editor/query-editor.tsx
+++ b/src/components/database/queries/editor/query-editor.tsx
@@ -99,17 +99,14 @@ import { TextAreaField } from '@/components/ui/form-inputs/TextAreaField';
 import {
   assignmentOperations,
   comparisonOperations,
-  inputTypes,
   operationTypes,
-  placementTypes,
   valueSourceTypes,
 } from './constants';
 import {
-  getPlacementIcon,
-  getPlacementName,
   getReadableOperation,
   getTypeIcon,
 } from '@/components/database/queries/editor/utils';
+import { QueryInputItem } from '@/components/database/queries/editor/query-input-item';
 import { useQueryWorkspaceOptional } from '@/components/database/queries/query-workspace-context';
 import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
 import {
@@ -1748,217 +1745,18 @@ export function QueryEditor({
                   </div>
 
                   <TabsContent value="form" className="space-y-4">
+                    {fields.length === 0 && (
+                      <p className="rounded-lg border border-dashed border-border/80 px-3 py-6 text-center text-sm text-muted-foreground">
+                        No inputs yet. Add the parameters callers will send.
+                      </p>
+                    )}
                     {fields.map((field, index) => (
-                      <Collapsible
+                      <QueryInputItem
                         key={field.id}
-                        className="border rounded-md overflow-hidden"
-                      >
-                        <div className="flex items-center justify-between p-3 bg-muted/30 cursor-pointer">
-                          <CollapsibleTrigger className="flex items-center space-x-2 grow justify-between text-left cursor-pointer mr-2">
-                            <div
-                              className={
-                                'flex flex-row space-x-2 text-left items-center'
-                              }
-                            >
-                              <ChevronDown className="h-4 w-4 shrink-0 transition-transform ui-open:rotate-180" />
-                              <span className="font-medium truncate">
-                                {form.watch(`inputs.${index}.name`) ||
-                                  `Input #${index + 1}`}
-                              </span>
-                            </div>
-                            {form.watch(`inputs.${index}.name`) && (
-                              <div className="flex items-center space-x-2">
-                                <div className="flex items-center space-x-1">
-                                  {getTypeIcon(
-                                    ValueTypeEnum[
-                                      form.watch(
-                                        `inputs.${index}.type`
-                                      ) as keyof typeof ValueTypeEnum
-                                    ]
-                                  )}
-                                  <Badge variant="outline" className="text-xs">
-                                    {form.watch(`inputs.${index}.type`)}
-                                    {form.watch(`inputs.${index}.array`) &&
-                                      '[]'}
-                                  </Badge>
-                                </div>
-
-                                <div className="flex items-center space-x-1">
-                                  {getPlacementIcon(
-                                    form.watch(
-                                      `inputs.${index}.location`
-                                    ) as LocationEnum
-                                  )}
-                                  <Badge
-                                    variant="secondary"
-                                    className="text-xs"
-                                  >
-                                    {getPlacementName(
-                                      form.watch(
-                                        `inputs.${index}.location`
-                                      ) as LocationEnum
-                                    )}
-                                  </Badge>
-                                </div>
-
-                                {form.watch(`inputs.${index}.optional`) && (
-                                  <Badge variant="outline" className="text-xs">
-                                    Optional
-                                  </Badge>
-                                )}
-                              </div>
-                            )}
-                          </CollapsibleTrigger>
-                          <TooltipProvider delayDuration={300}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon"
-                                  aria-label={`Remove input ${form.watch(`inputs.${index}.name`) || index + 1}`}
-                                  onClick={() => remove(index)}
-                                >
-                                  <Trash2 className="h-4 w-4 text-destructive" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                Remove this input from the draft. Save to
-                                persist.
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        </div>
-
-                        <CollapsibleContent>
-                          <div className="p-4 space-y-4">
-                            <div className="space-y-2">
-                              <InputField
-                                label={'Name'}
-                                fieldName={`inputs.${index}.name`}
-                                placeholder={'e.g. id, name, filter'}
-                              />
-                            </div>
-
-                            <div className="grid grid-cols-2 gap-4">
-                              <div className="space-y-2">
-                                <SelectField
-                                  label={'Type'}
-                                  fieldName={`inputs.${index}.type`}
-                                  placeholder="Select type"
-                                  options={inputTypes.map(type => ({
-                                    value: type.value,
-                                    label: (
-                                      <div className="flex items-center space-x-2">
-                                        {getTypeIcon(type.value)}
-                                        <span>{type.label}</span>
-                                      </div>
-                                    ),
-                                  }))}
-                                />
-                              </div>
-
-                              <div className="space-y-2">
-                                <SelectField
-                                  label={'Placement'}
-                                  fieldName={`inputs.${index}.location`}
-                                  placeholder="Select placement"
-                                  options={placementTypes.map(place => ({
-                                    value: place.value,
-                                    label: (
-                                      <div className="flex items-center gap-2">
-                                        {getPlacementIcon(place.value)}
-                                        <div className="flex flex-col">
-                                          <span>{place.label}</span>
-                                          <span className="text-xs text-muted-foreground">
-                                            {place.description}
-                                          </span>
-                                        </div>
-                                      </div>
-                                    ),
-                                  }))}
-                                />
-                                {form.watch(`inputs.${index}.location`) ===
-                                  LocationEnum.BODY &&
-                                  [
-                                    OperationsEnum.GET,
-                                    OperationsEnum.DELETE,
-                                  ].includes(operation) && (
-                                    <p className="text-xs text-destructive">
-                                      Body parameters are not allowed for{' '}
-                                      Find/Delete operations
-                                    </p>
-                                  )}
-                              </div>
-                            </div>
-
-                            <div className="flex flex-wrap gap-6">
-                              <FormField
-                                control={form.control}
-                                name={`inputs.${index}.optional`}
-                                render={({ field }) => (
-                                  <FormItem className="flex flex-row items-center gap-2">
-                                    <FormControl>
-                                      <Checkbox
-                                        id={`inputs.${index}.optional`}
-                                        checked={Boolean(field.value)}
-                                        disabled={
-                                          form.watch(
-                                            `inputs.${index}.location`
-                                          ) === LocationEnum.URL
-                                        }
-                                        onCheckedChange={checked =>
-                                          field.onChange(Boolean(checked))
-                                        }
-                                      />
-                                    </FormControl>
-                                    <div className="flex items-center gap-1">
-                                      <FormLabel
-                                        htmlFor={`inputs.${index}.optional`}
-                                        className="font-normal"
-                                      >
-                                        Optional
-                                      </FormLabel>
-                                      <QueryFieldHint content="Path parameters cannot be optional. Query and body inputs can be omitted by the client." />
-                                    </div>
-                                  </FormItem>
-                                )}
-                              />
-                              <FormField
-                                control={form.control}
-                                name={`inputs.${index}.array`}
-                                render={({ field }) => (
-                                  <FormItem className="flex flex-row items-center gap-2">
-                                    <FormControl>
-                                      <Checkbox
-                                        id={`inputs.${index}.array`}
-                                        checked={Boolean(field.value)}
-                                        disabled={
-                                          form.watch(
-                                            `inputs.${index}.location`
-                                          ) === LocationEnum.URL
-                                        }
-                                        onCheckedChange={checked =>
-                                          field.onChange(Boolean(checked))
-                                        }
-                                      />
-                                    </FormControl>
-                                    <div className="flex items-center gap-1">
-                                      <FormLabel
-                                        htmlFor={`inputs.${index}.array`}
-                                        className="font-normal"
-                                      >
-                                        Is array
-                                      </FormLabel>
-                                      <QueryFieldHint content="Accept multiple values. Path parameters cannot be arrays." />
-                                    </div>
-                                  </FormItem>
-                                )}
-                              />
-                            </div>
-                          </div>
-                        </CollapsibleContent>
-                      </Collapsible>
+                        index={index}
+                        operation={operation}
+                        onRemove={() => remove(index)}
+                      />
                     ))}
 
                     <Button

--- a/src/components/database/queries/editor/query-editor.tsx
+++ b/src/components/database/queries/editor/query-editor.tsx
@@ -29,20 +29,11 @@ import {
   Plus,
   PlusIcon as LogicalAnd,
   Save,
-  Search,
   Settings,
   Trash2,
 } from 'lucide-react';
 import { rhfZodResolver } from '@/lib/zod-form';
 import { Separator } from '@/components/ui/separator';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { toast } from '@/lib/hooks/use-toast';
 import {
@@ -52,8 +43,6 @@ import {
 } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
@@ -71,7 +60,6 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
-import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -99,7 +87,6 @@ import { TextAreaField } from '@/components/ui/form-inputs/TextAreaField';
 import {
   assignmentOperations,
   comparisonOperations,
-  operationTypes,
   valueSourceTypes,
 } from './constants';
 import {
@@ -107,6 +94,7 @@ import {
   getTypeIcon,
 } from '@/components/database/queries/editor/utils';
 import { QueryInputItem } from '@/components/database/queries/editor/query-input-item';
+import { QueryInformation } from '@/components/database/queries/editor/query-information';
 import { useQueryWorkspaceOptional } from '@/components/database/queries/query-workspace-context';
 import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
 import {
@@ -253,7 +241,6 @@ export function QueryEditor({
   const router = useRouter();
   const [models, setModels] = React.useState<DeclaredSchema[]>([]);
   const [modelsLoading, setModelsLoading] = React.useState(true);
-  const [isModelDialogOpen, setIsModelDialogOpen] = React.useState(false);
   const [modelSearchTerm, setModelSearchTerm] = React.useState('');
   const [inputMode, setInputMode] = React.useState<'form' | 'json'>('form');
   const [queryMode, setQueryMode] = React.useState<'form' | 'json'>('form');
@@ -1459,259 +1446,14 @@ export function QueryEditor({
             </Alert>
           )}
 
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            <Card>
-              <CardHeader>
-                <CardTitle>Query Information</CardTitle>
-                <CardDescription>
-                  Name, model, and runtime options for this endpoint
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-2">
-                  <InputField
-                    label={'Query Name'}
-                    fieldName={'name'}
-                    placeholder="GetUsersByTeam"
-                    info="Becomes the Client API path: /database/function/{name}. Spaces are not allowed."
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <TextAreaField
-                    label={'Description'}
-                    fieldName={'endpointDescription'}
-                    placeholder="Describe what this query does"
-                    rows={3}
-                  />
-                </div>
-
-                <FormField
-                  control={form.control}
-                  name="authentication"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-                      <div className="space-y-0.5">
-                        <div className="flex items-center gap-1.5">
-                          <FormLabel
-                            htmlFor="query-authentication"
-                            className="text-base font-medium"
-                          >
-                            Requires Authentication
-                          </FormLabel>
-                          <QueryFieldHint content="When enabled, callers must send a user bearer token. Anonymous Client API requests are rejected." />
-                        </div>
-                        <FormDescription>
-                          When enabled, this query is only accessible to
-                          authenticated users.
-                        </FormDescription>
-                      </div>
-                      <FormControl>
-                        <Switch
-                          id="query-authentication"
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                {operation === OperationsEnum.GET && (
-                  <div className="space-y-3">
-                    <FormField
-                      control={form.control}
-                      name="paginated"
-                      render={({ field }) => (
-                        <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-                          <div className="space-y-0.5">
-                            <div className="flex items-center gap-1.5">
-                              <FormLabel
-                                htmlFor="query-paginated"
-                                className="text-base font-medium"
-                              >
-                                Paginated
-                              </FormLabel>
-                              <QueryFieldHint content="Adds skip and limit query parameters and returns a document count with results." />
-                            </div>
-                            <FormDescription>
-                              Expose skip and limit query parameters and return
-                              a document count with results.
-                            </FormDescription>
-                          </div>
-                          <FormControl>
-                            <Switch
-                              id="query-paginated"
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name="sorted"
-                      render={({ field }) => (
-                        <FormItem className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-                          <div className="space-y-0.5">
-                            <div className="flex items-center gap-1.5">
-                              <FormLabel
-                                htmlFor="query-sorted"
-                                className="text-base font-medium"
-                              >
-                                Sorted
-                              </FormLabel>
-                              <QueryFieldHint content="Allows clients to pass sort query parameters on GET requests." />
-                            </div>
-                            <FormDescription>
-                              Allow clients to pass sort query parameters on GET
-                              requests.
-                            </FormDescription>
-                          </div>
-                          <FormControl>
-                            <Switch
-                              id="query-sorted"
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </div>
-                )}
-
-                <div className="space-y-2">
-                  <div className="flex items-center gap-1">
-                    <span className="text-sm font-medium">Operation</span>
-                    <QueryFieldHint
-                      content={
-                        initialData?._id
-                          ? 'The HTTP method is part of the endpoint contract and cannot change after create.'
-                          : 'Maps to the HTTP method clients will call on /database/function/{name}.'
-                      }
-                    />
-                  </div>
-                  <SelectField
-                    label={'Operation'}
-                    placeholder="Select operation"
-                    disabled={!!initialData?._id}
-                    classNames={{
-                      label: 'sr-only',
-                      selectTrigger:
-                        '[&>span>div]:flex-row [&>span>div]:items-center [&>span>div]:justify-start [&>span>div]:gap-2',
-                    }}
-                    options={operationTypes.map(op => ({
-                      value: op.value,
-                      label: (
-                        <div className="flex flex-col">
-                          <span>
-                            {op.label} · {getOperationMeta(op.value).method}
-                          </span>
-                          <span className="text-xs text-muted-foreground">
-                            {op.description}
-                          </span>
-                        </div>
-                      ),
-                    }))}
-                    fieldName={'operation'}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <div className="flex items-center gap-1">
-                    <Label htmlFor="model">Model</Label>
-                    <QueryFieldHint
-                      content={
-                        initialData?._id
-                          ? 'The target schema is locked after create.'
-                          : 'The schema this endpoint reads or writes.'
-                      }
-                    />
-                  </div>
-                  <Dialog
-                    open={isModelDialogOpen}
-                    onOpenChange={setIsModelDialogOpen}
-                  >
-                    <DialogTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className="w-full justify-start"
-                        disabled={!!initialData?._id}
-                      >
-                        {form.watch('selectedSchemaName') || 'Select a model'}
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent className="sm:max-w-md">
-                      <DialogHeader>
-                        <DialogTitle>Select Model</DialogTitle>
-                      </DialogHeader>
-                      <div className="space-y-4">
-                        <div className="flex items-center space-x-2">
-                          <Search className="w-4 h-4 text-muted-foreground" />
-                          <Input
-                            placeholder="Search models..."
-                            value={modelSearchTerm}
-                            onChange={e => setModelSearchTerm(e.target.value)}
-                          />
-                        </div>
-                        <ScrollArea className="h-[300px]">
-                          <div className="flex flex-col gap-2">
-                            {modelsLoading && (
-                              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-                                Loading models…
-                              </p>
-                            )}
-                            {!modelsLoading && filteredModels.length === 0 && (
-                              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-                                No models match this operation and search.
-                              </p>
-                            )}
-                            {filteredModels.map(model => (
-                              <Button
-                                key={model._id}
-                                variant="ghost"
-                                className="w-full justify-start text-left"
-                                onClick={() => {
-                                  form.setValue('selectedSchema', model._id, {
-                                    shouldValidate: true,
-                                    shouldDirty: true,
-                                    shouldTouch: true,
-                                  });
-                                  form.setValue(
-                                    'selectedSchemaName',
-                                    model.name,
-                                    {
-                                      shouldValidate: true,
-                                      shouldDirty: true,
-                                      shouldTouch: true,
-                                    }
-                                  );
-                                  setIsModelDialogOpen(false);
-                                }}
-                              >
-                                <div className="flex flex-col">
-                                  <span>{model.name}</span>
-                                </div>
-                              </Button>
-                            ))}
-                          </div>
-                        </ScrollArea>
-                      </div>
-                    </DialogContent>
-                  </Dialog>
-                  {form.formState.errors.selectedSchema && (
-                    <p className="text-sm text-destructive">
-                      {form.formState.errors.selectedSchema.message}
-                    </p>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
+          <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
+            <QueryInformation
+              contractLocked={!!initialData?._id}
+              modelsLoading={modelsLoading}
+              filteredModels={filteredModels}
+              modelSearchTerm={modelSearchTerm}
+              onModelSearchChange={setModelSearchTerm}
+            />
 
             <Card>
               <CardHeader>

--- a/src/components/database/queries/editor/query-editor.tsx
+++ b/src/components/database/queries/editor/query-editor.tsx
@@ -8,18 +8,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import {
-  Controller,
-  useFieldArray,
-  useForm,
-  type FieldPath,
-} from 'react-hook-form';
+import { useFieldArray, useForm } from 'react-hook-form';
 import * as React from 'react';
 import { useEffect } from 'react';
 import {
-  BinaryIcon as LogicalOr,
   Check,
-  ChevronDown,
   Code,
   Copy,
   FileJson,
@@ -27,23 +20,15 @@ import {
   FormInput,
   Loader2,
   Plus,
-  PlusIcon as LogicalAnd,
   Save,
-  Settings,
   Trash2,
 } from 'lucide-react';
 import { rhfZodResolver } from '@/lib/zod-form';
 import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { toast } from '@/lib/hooks/use-toast';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   Tooltip,
@@ -51,26 +36,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { Form } from '@/components/ui/form';
 import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  Assignment,
   AssignmentActionEnum,
-  Comparison,
   ComparisonOperationEnum,
   CustomEndpoint,
   LocationEnum,
@@ -79,22 +47,17 @@ import {
   ValueTypeEnum,
 } from '@/lib/models/database/custom-endpoints';
 import { z } from 'zod';
-import { InputField } from '@/components/ui/form-inputs/InputField';
 import { getSchemas } from '@/lib/api/database';
 import { DeclaredSchema } from '@/lib/models/database';
-import SelectField from '@/components/ui/form-inputs/SelectField';
 import { TextAreaField } from '@/components/ui/form-inputs/TextAreaField';
-import {
-  assignmentOperations,
-  comparisonOperations,
-  valueSourceTypes,
-} from './constants';
-import {
-  getReadableOperation,
-  getTypeIcon,
-} from '@/components/database/queries/editor/utils';
 import { QueryInputItem } from '@/components/database/queries/editor/query-input-item';
 import { QueryInformation } from '@/components/database/queries/editor/query-information';
+import {
+  countConditions,
+  QueryAssignments,
+  QueryConditionGroup,
+} from '@/components/database/queries/editor/query-condition-group';
+import { QueryModelField } from '@/components/database/queries/editor/query-compact-fields';
 import { useQueryWorkspaceOptional } from '@/components/database/queries/query-workspace-context';
 import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
 import {
@@ -102,13 +65,6 @@ import {
   getOperationMeta,
 } from '@/components/database/queries/query-operations';
 import { useRouter } from 'next/navigation';
-import { cn } from '@/lib/utils';
-
-interface ModelField {
-  name: string;
-  type: string;
-  isArray: boolean;
-}
 
 /** Radix Select passes string values; API may return numbers for these enums. */
 const numericEnum = (e: Parameters<typeof z.nativeEnum>[0]) =>
@@ -190,8 +146,6 @@ const querySchema = z.object({
 });
 
 type QueryFormValues = z.infer<typeof querySchema>;
-/** Nested condition paths are built at runtime; widen for react-hook-form APIs. */
-type QueryFormPath = FieldPath<QueryFormValues>;
 
 const INPUTS_JSON_PLACEHOLDER = `[
   {
@@ -298,22 +252,10 @@ export function QueryEditor({
     );
   }, []);
 
-  const setDirtyValue = (
-    path: string,
-    value: unknown,
-    options?: { shouldValidate?: boolean }
-  ) => {
-    form.setValue(path as QueryFormPath, value as never, {
-      shouldDirty: true,
-      shouldTouch: true,
-      shouldValidate: options?.shouldValidate ?? true,
-    });
-  };
-
-  const [modelFields, setModelFields] = React.useState<ModelField[]>([]);
-  const [modifiableFields, setModifiableFields] = React.useState<ModelField[]>(
-    []
-  );
+  const [modelFields, setModelFields] = React.useState<QueryModelField[]>([]);
+  const [modifiableFields, setModifiableFields] = React.useState<
+    QueryModelField[]
+  >([]);
   useEffect(() => {
     if (!selectedSchema) return;
     const parsedSchema = models.find(model => model._id === selectedSchema);
@@ -380,28 +322,6 @@ export function QueryEditor({
     control: form.control,
     name: 'inputs',
   });
-
-  const addConditionToGroup = (path: string, condition: any) => {
-    const currentGroup = form.getValues(path as any) as unknown[];
-    const updatedConditions = [...currentGroup, condition];
-    setDirtyValue(path, updatedConditions);
-  };
-
-  const addNestedGroup = (path: string, groupType: 'AND' | 'OR') => {
-    const currentGroup = form.getValues(path as any) as unknown[];
-    const newGroup = {
-      [groupType]: [],
-    };
-    const updatedConditions = [...currentGroup, newGroup];
-    setDirtyValue(path, updatedConditions);
-  };
-
-  const removeFromGroup = (path: string, index: number) => {
-    const currentGroup = form.getValues(path as any) as unknown[];
-    const updatedConditions = [...currentGroup];
-    updatedConditions.splice(index, 1);
-    setDirtyValue(path, updatedConditions);
-  };
 
   const {
     fields: setConditions,
@@ -703,627 +623,9 @@ export function QueryEditor({
     setQueryMode(mode);
   };
 
-  const countConditions = (group: unknown): number => {
-    if (!group || typeof group !== 'object') return 0;
-    const nested = group as { AND?: unknown[]; OR?: unknown[] };
-    const items = nested.AND ?? nested.OR;
-    if (!Array.isArray(items)) return 0;
-    return items.reduce((count: number, condition: unknown) => {
-      if (
-        condition &&
-        typeof condition === 'object' &&
-        ('AND' in condition || 'OR' in condition)
-      ) {
-        return count + countConditions(condition);
-      }
-      return count + 1;
-    }, 0);
-  };
-
-  const getConditionDescription = (condition: Comparison): string => {
-    const { schemaField, operation, comparisonField } = condition;
-
-    if (!schemaField) return '';
-
-    let valueDisplay = '';
-    if (comparisonField.type === ValueSourceTypeEnum.INPUT) {
-      valueDisplay = `input:${comparisonField.value || 'not selected'}`;
-    } else if (comparisonField.type === ValueSourceTypeEnum.CUSTOM) {
-      valueDisplay = comparisonField.value || 'empty';
-    } else if (comparisonField.type === ValueSourceTypeEnum.CONTEXT) {
-      valueDisplay = `context:${comparisonField.value || 'not specified'}`;
-    }
-
-    let opPhrase = getReadableOperation(operation);
-    if (comparisonField.like && operation === ComparisonOperationEnum.EQUAL) {
-      opPhrase = comparisonField.caseSensitiveLike
-        ? 'matches (case-sensitive LIKE)'
-        : 'matches (LIKE)';
-    }
-
-    return `${schemaField} ${opPhrase} ${valueDisplay}`;
-  };
-
-  const getSetDescription = (condition: Assignment, index: number): string => {
-    const { schemaField, action, assignmentField } = condition;
-    if (!schemaField) return `Set #${index + 1}`;
-    if (!assignmentField.value) return `Set #${index + 1}`;
-    let valueDisplay = '';
-    if (assignmentField.type === ValueSourceTypeEnum.INPUT) {
-      valueDisplay = `input:${assignmentField.value || 'not selected'}`;
-    } else if (assignmentField.type === ValueSourceTypeEnum.CUSTOM) {
-      valueDisplay = assignmentField.value || 'empty';
-    } else if (assignmentField.type === ValueSourceTypeEnum.CONTEXT) {
-      valueDisplay = `context:${assignmentField.value || 'not specified'}`;
-    }
-
-    switch (action) {
-      case AssignmentActionEnum.ASSIGN:
-        return `${schemaField} = ${valueDisplay}`;
-      case AssignmentActionEnum.INC:
-        return `${schemaField}+=${valueDisplay}`;
-      case AssignmentActionEnum.DEC:
-        return `${schemaField}-=${valueDisplay}`;
-      case AssignmentActionEnum.PUSH:
-        return `${schemaField}=${schemaField}.concat(${valueDisplay})`;
-      case AssignmentActionEnum.PULL:
-        return `${schemaField}=${schemaField}.remove(${valueDisplay})`;
-      default:
-        return `${schemaField} = ${valueDisplay}`;
-    }
-  };
-
-  const renderCondition = (
-    condition: Comparison,
-    path: string,
-    index: number,
-    parentPath: string
-  ) => {
-    const qp = (suffix: string) => `${path}.${suffix}` as QueryFormPath;
-
-    // Get a readable description of the condition
-    const conditionDescription = getConditionDescription(condition);
-    const conditionTitle = conditionDescription || `Condition #${index + 1}`;
-
-    return (
-      <Collapsible
-        key={`${path}-${index}`}
-        className="border rounded-md overflow-hidden mb-4"
-      >
-        <div className="flex items-center justify-between p-3 bg-muted/30">
-          <div className="flex items-center space-x-2 grow">
-            <CollapsibleTrigger className="flex items-center space-x-2 grow text-left">
-              <ChevronDown className="h-4 w-4 shrink-0 transition-transform ui-open:rotate-180" />
-              <span className="font-medium truncate">{conditionTitle}</span>
-            </CollapsibleTrigger>
-            {form.watch(qp('schemaField')) && (
-              <div className="flex items-center space-x-2">
-                <Badge variant="outline">
-                  {comparisonOperations.find(
-                    o => o.value === form.watch(qp('operation'))
-                  )?.label ?? form.watch(qp('operation'))}
-                </Badge>
-                <Badge variant="secondary">
-                  {form.watch(qp('comparisonField.type'))}
-                </Badge>
-              </div>
-            )}
-          </div>
-
-          <TooltipProvider delayDuration={300}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Remove condition"
-                  onClick={() => removeFromGroup(parentPath, index)}
-                >
-                  <Trash2 className="h-4 w-4 text-destructive" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                Remove this condition from the draft. Save to persist.
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-
-        <CollapsibleContent>
-          <div className="p-4 space-y-4">
-            <div className="space-y-2">
-              <SelectField
-                label={'Field'}
-                placeholder={'Select field'}
-                fieldName={qp('schemaField')}
-                options={modelFields.map(modelField => ({
-                  value: modelField.name,
-                  label: (
-                    <div className="flex items-center space-x-2">
-                      {getTypeIcon(modelField.type as ValueTypeEnum)}
-                      <span>{modelField.name}</span>
-                      {modelField.isArray && (
-                        <Badge variant="outline" className="ml-1 text-xs">
-                          Array
-                        </Badge>
-                      )}
-                    </div>
-                  ),
-                }))}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Controller
-                name={qp('operation')}
-                control={form.control}
-                render={({ field }) => (
-                  <FormItem className="space-y-2">
-                    <FormLabel>Comparison</FormLabel>
-                    <Select
-                      onValueChange={val => {
-                        const n = Number(val);
-                        field.onChange(n);
-                        if (n !== ComparisonOperationEnum.EQUAL) {
-                          form.setValue(qp('comparisonField.like'), false, {
-                            shouldDirty: true,
-                          });
-                          form.setValue(
-                            qp('comparisonField.caseSensitiveLike'),
-                            false,
-                            { shouldDirty: true }
-                          );
-                        }
-                      }}
-                      value={String(
-                        field.value ?? ComparisonOperationEnum.EQUAL
-                      )}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select comparison" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {comparisonOperations.map(op => (
-                          <SelectItem key={op.value} value={String(op.value)}>
-                            {op.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <SelectField
-                label={'Value Source'}
-                placeholder={'Select value source'}
-                fieldName={qp('comparisonField.type')}
-                description="Where the compared value comes from at request time."
-                options={valueSourceTypes.map(vs => ({
-                  value: vs.value,
-                  label: (
-                    <div className="flex flex-col">
-                      <span>{vs.label}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {vs.description}
-                      </span>
-                    </div>
-                  ),
-                }))}
-              />
-            </div>
-
-            {form.watch(qp('comparisonField.type')) ===
-              ValueSourceTypeEnum.INPUT && (
-              <div className="space-y-2">
-                <SelectField
-                  label={'Input'}
-                  placeholder={'Select input'}
-                  options={inputs.map(input => ({
-                    value: input.name,
-                    label: input.name,
-                  }))}
-                  fieldName={qp('comparisonField.value')}
-                />
-              </div>
-            )}
-
-            {form.watch(qp('comparisonField.type')) ===
-              ValueSourceTypeEnum.CUSTOM && (
-              <div className="space-y-2">
-                <InputField
-                  label={'Custom Value'}
-                  fieldName={qp('comparisonField.value')}
-                  placeholder={'Enter custom value'}
-                />
-              </div>
-            )}
-            {form.watch(qp('comparisonField.type')) ===
-              ValueSourceTypeEnum.CONTEXT && (
-              <div className="space-y-2">
-                <InputField
-                  label={'Context Value'}
-                  fieldName={qp('comparisonField.value')}
-                  placeholder={'e.g. user._id'}
-                  info="Request context path, such as user._id. Resolved when the endpoint runs."
-                />
-              </div>
-            )}
-
-            {Number(form.watch(qp('operation'))) ===
-              ComparisonOperationEnum.EQUAL && (
-              <div className="space-y-4 rounded-md border border-border/60 bg-muted/20 p-3">
-                <Controller
-                  name={qp('comparisonField.like')}
-                  control={form.control}
-                  render={({ field }) => (
-                    <FormItem className="flex flex-row items-start gap-3">
-                      <FormControl>
-                        <Checkbox
-                          checked={Boolean(field.value)}
-                          onCheckedChange={checked => {
-                            const isChecked = Boolean(checked);
-                            field.onChange(isChecked);
-                            if (!isChecked) {
-                              form.setValue(
-                                qp('comparisonField.caseSensitiveLike'),
-                                false,
-                                { shouldDirty: true }
-                              );
-                            }
-                          }}
-                        />
-                      </FormControl>
-                      <div className="flex flex-col gap-1 leading-none">
-                        <FormLabel className="font-normal">
-                          Like (pattern match)
-                        </FormLabel>
-                        <FormDescription className="text-xs">
-                          Use % as a wildcard; the value is matched as %input%.
-                        </FormDescription>
-                      </div>
-                    </FormItem>
-                  )}
-                />
-                {Boolean(form.watch(qp('comparisonField.like'))) && (
-                  <Controller
-                    name={qp('comparisonField.caseSensitiveLike')}
-                    control={form.control}
-                    render={({ field }) => (
-                      <FormItem className="flex flex-row items-center gap-3">
-                        <FormControl>
-                          <Checkbox
-                            checked={Boolean(field.value)}
-                            onCheckedChange={checked =>
-                              field.onChange(Boolean(checked))
-                            }
-                          />
-                        </FormControl>
-                        <div className="flex flex-col gap-1 leading-none">
-                          <FormLabel className="font-normal">
-                            Case sensitive
-                          </FormLabel>
-                          <FormDescription className="text-xs">
-                            When off, matching is case-insensitive (e.g. ILIKE
-                            on PostgreSQL).
-                          </FormDescription>
-                        </div>
-                      </FormItem>
-                    )}
-                  />
-                )}
-              </div>
-            )}
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-    );
-  };
-
-  const renderConditionGroup = (
-    group: any,
-    path = 'query',
-    isNested = false
-  ) => {
-    const groupRoot = form.watch(path as QueryFormPath) as {
-      AND?: unknown;
-      OR?: unknown;
-    };
-    const groupType = groupRoot?.AND ? 'AND' : 'OR';
-    const conditions =
-      (form.watch(`${path}.${groupType}` as QueryFormPath) as unknown[]) || [];
-    return (
-      <div
-        className={cn(
-          'mb-4 rounded-md border p-4',
-          groupType === 'AND' ? 'border-primary/30' : 'border-border'
-        )}
-      >
-        <div className="mb-4 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {groupType === 'AND' ? (
-              <LogicalAnd className="h-5 w-5 text-primary" />
-            ) : (
-              <LogicalOr className="h-5 w-5 text-muted-foreground" />
-            )}
-            <SelectField
-              label={''}
-              value={
-                (form.watch(path as QueryFormPath) as { AND?: unknown })?.AND
-                  ? 'AND'
-                  : 'OR'
-              }
-              onValueChange={val => {
-                const current = form.watch(path as keyof QueryFormValues) as {
-                  AND?: unknown;
-                  OR?: unknown;
-                };
-                if (current['AND']) {
-                  setDirtyValue(path, { [val]: current['AND'] });
-                } else {
-                  setDirtyValue(path, { [val]: current['OR'] });
-                }
-              }}
-              options={[
-                { value: 'AND', label: 'AND' },
-                { value: 'OR', label: 'OR' },
-              ]}
-            />
-
-            {isNested && (
-              <Badge variant={groupType === 'AND' ? 'secondary' : 'outline'}>
-                {countConditions(groupRoot)} condition
-                {countConditions(groupRoot) !== 1 ? 's' : ''}
-              </Badge>
-            )}
-          </div>
-
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                addConditionToGroup(`${path}.${groupType}`, {
-                  schemaField: '',
-                  operation: ComparisonOperationEnum.EQUAL,
-                  comparisonField: {
-                    type: ValueSourceTypeEnum.INPUT,
-                    value: '',
-                  },
-                } as Comparison)
-              }
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              Add Condition
-            </Button>
-
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                addNestedGroup(
-                  path === 'query' ? `${path}.${groupType}` : path,
-                  groupType === 'AND' ? 'OR' : 'AND'
-                )
-              }
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              Add {groupType === 'AND' ? 'OR' : 'AND'} Group
-            </Button>
-
-            {isNested && (
-              <TooltipProvider delayDuration={300}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label="Remove group"
-                      onClick={() => {
-                        const pathParts = path.split('.');
-                        const index = Number.parseInt(pathParts.pop() ?? '0');
-                        const parentPath = pathParts.join('.');
-                        removeFromGroup(parentPath, index);
-                      }}
-                    >
-                      <Trash2 className="h-4 w-4 text-destructive" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Remove this group from the draft. Save to persist.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-          </div>
-        </div>
-
-        <div
-          className={cn(
-            'border-l-2 pl-4',
-            groupType === 'AND' ? 'border-primary/30' : 'border-border'
-          )}
-        >
-          {conditions.length === 0 ? (
-            <div className="flex items-center justify-center p-6 bg-muted/20 rounded-md">
-              <div className="text-center text-muted-foreground">
-                <p>No conditions in this {groupType} group</p>
-                <p className="text-sm">Add conditions or nested groups</p>
-              </div>
-            </div>
-          ) : (
-            conditions.map((condition: any, index: number) => {
-              // Check if this is a condition or a group
-              if (condition['AND'] || condition['OR']) {
-                // It's a group, render recursively
-                return renderConditionGroup(
-                  condition,
-                  `${path}.${groupType}.${index}`,
-                  true
-                );
-              } else {
-                // It's a condition
-                return renderCondition(
-                  condition,
-                  `${path}.${groupType}.${index}`,
-                  index,
-                  `${path}.${groupType}`
-                );
-              }
-            })
-          )}
-        </div>
-      </div>
-    );
-  };
-
-  const renderSetCondition = (condition: any, index: number) => {
-    return (
-      <Collapsible
-        key={condition.id}
-        className="border rounded-md overflow-hidden mb-4"
-      >
-        <div className="flex items-center justify-between p-3 bg-muted/30">
-          <div className="flex items-center space-x-2 grow">
-            <CollapsibleTrigger className="flex items-center space-x-2 grow text-left">
-              <ChevronDown className="h-4 w-4 shrink-0 transition-transform ui-open:rotate-180" />
-              <span className="font-medium truncate">
-                {getSetDescription(condition, index)}
-              </span>
-            </CollapsibleTrigger>
-
-            {form.watch(`assignments.${index}.schemaField`) && (
-              <Badge variant="secondary">
-                {form.watch(`assignments.${index}.assignmentField.type`)}
-              </Badge>
-            )}
-          </div>
-
-          <TooltipProvider delayDuration={300}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Remove set value"
-                  onClick={() => removeSetCondition(index)}
-                >
-                  <Trash2 className="h-4 w-4 text-destructive" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                Remove this assignment from the draft. Save to persist.
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-
-        <CollapsibleContent>
-          <div className="p-4 space-y-4">
-            <div className="space-y-2">
-              <SelectField
-                label={'Field'}
-                fieldName={`assignments.${index}.schemaField`}
-                options={modifiableFields.map(modelField => ({
-                  value: modelField.name,
-                  label: (
-                    <div className="flex items-center space-x-2">
-                      {getTypeIcon(modelField.type as ValueTypeEnum)}
-                      <span>{modelField.name}</span>
-                      {modelField.isArray && (
-                        <Badge variant="outline" className="ml-1 text-xs">
-                          Array
-                        </Badge>
-                      )}
-                    </div>
-                  ),
-                }))}
-              />
-            </div>
-            <div className="space-y-2">
-              <SelectField
-                label={'Assignment Action'}
-                fieldName={`assignments.${index}.action`}
-                options={assignmentOperations.map(vs => ({
-                  label: vs.label,
-                  value: vs.value,
-                }))}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <SelectField
-                label={'Value Source'}
-                fieldName={`assignments.${index}.assignmentField.type`}
-                description="Where the assigned value comes from at request time."
-                options={valueSourceTypes.map(vs => ({
-                  label: (
-                    <div className="flex flex-col">
-                      <span>{vs.label}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {vs.description}
-                      </span>
-                    </div>
-                  ),
-                  value: vs.value,
-                }))}
-              />
-            </div>
-
-            {form.watch(`assignments.${index}.assignmentField.type`) ===
-              ValueSourceTypeEnum.INPUT && (
-              <div className="space-y-2">
-                <SelectField
-                  label={'Value from Input'}
-                  fieldName={`assignments.${index}.assignmentField.value`}
-                  options={form.watch(`inputs`).map(input => ({
-                    value: input.name,
-                    label: input.name,
-                  }))}
-                />
-              </div>
-            )}
-
-            {form.watch(`assignments.${index}.assignmentField.type`) ===
-              ValueSourceTypeEnum.CUSTOM && (
-              <div className="space-y-2">
-                <InputField
-                  label={'Custom Value'}
-                  fieldName={`assignments.${index}.assignmentField.value`}
-                  placeholder={'Enter custom value'}
-                />
-              </div>
-            )}
-
-            {form.watch(`assignments.${index}.assignmentField.type`) ===
-              ValueSourceTypeEnum.CONTEXT && (
-              <div className="space-y-2">
-                <InputField
-                  label={'Context Value'}
-                  fieldName={`assignments.${index}.assignmentField.value`}
-                  placeholder={'e.g. user._id'}
-                  info="Request context path, such as user._id. Resolved when the endpoint runs."
-                />
-              </div>
-            )}
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-    );
-  };
-
   const operationMeta = getOperationMeta(operation);
   const endpointPath = getEndpointPath(queryName);
+  const findConditionCount = countConditions(form.watch('query'));
 
   const handleCopyPath = async () => {
     try {
@@ -1605,67 +907,33 @@ export function QueryEditor({
                   </div>
 
                   <TabsContent value="form" className="space-y-6">
-                    <div className="space-y-4">
-                      <div className="flex items-center justify-between">
-                        <h3 className="flex items-center gap-1.5 text-lg font-medium">
-                          <Filter className="h-5 w-5" />
-                          Find Conditions
-                          <QueryFieldHint content="Documents must match this group. AND requires every condition; OR requires any condition." />
-                        </h3>
-                      </div>
-
-                      {renderConditionGroup('query')}
-                    </div>
+                    <QueryConditionGroup
+                      modelFields={modelFields}
+                      operation={operation}
+                    />
 
                     {supportsSetConditions && (
                       <>
                         <Separator />
-                        <div className="space-y-4">
-                          <div className="flex items-center justify-between">
-                            <h3 className="flex items-center gap-1.5 text-lg font-medium">
-                              <Settings className="h-5 w-5" />
-                              Set Values
-                              <QueryFieldHint content="Fields written when this Create, Update, or Patch endpoint runs." />
-                            </h3>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              onClick={() =>
-                                appendSetCondition({
-                                  schemaField: '',
-                                  action: AssignmentActionEnum.ASSIGN,
-                                  assignmentField: {
-                                    type: ValueSourceTypeEnum.INPUT,
-                                    value: '',
-                                  },
-                                })
-                              }
-                            >
-                              <Plus className="mr-2 h-4 w-4" />
-                              Add Set Value
-                            </Button>
-                          </div>
-
-                          {setConditions.length === 0 ? (
-                            <div className="flex items-center justify-center p-6 border rounded-md bg-muted/20">
-                              <div className="text-center text-muted-foreground">
-                                <Settings className="w-10 h-10 mx-auto mb-2 opacity-20" />
-                                <p>No set values defined</p>
-                                <p className="text-sm">
-                                  Add values to set in your{' '}
-                                  {operationMeta.label} operation
-                                </p>
-                              </div>
-                            </div>
-                          ) : (
-                            <div className="space-y-2">
-                              {setConditions.map((condition, index) =>
-                                renderSetCondition(condition, index)
-                              )}
-                            </div>
-                          )}
-                        </div>
+                        <QueryAssignments
+                          fields={setConditions}
+                          modifiableFields={modifiableFields}
+                          operationLabel={operationMeta.label}
+                          onAdd={() =>
+                            appendSetCondition({
+                              schemaField: '',
+                              action: AssignmentActionEnum.ASSIGN,
+                              assignmentField: {
+                                type:
+                                  (form.getValues('inputs') ?? []).length > 0
+                                    ? ValueSourceTypeEnum.INPUT
+                                    : ValueSourceTypeEnum.CUSTOM,
+                                value: '',
+                              },
+                            })
+                          }
+                          onRemove={removeSetCondition}
+                        />
                       </>
                     )}
                   </TabsContent>
@@ -1689,9 +957,9 @@ export function QueryEditor({
                 </Tabs>
               </CardContent>
               <CardFooter className="flex justify-between">
-                <div className="text-sm text-muted-foreground">
-                  {countConditions(form.watch('query'))} find condition
-                  {countConditions(form.watch('query')) !== 1 ? 's' : ''} and
+                <div className="text-sm text-muted-foreground tabular-nums">
+                  {findConditionCount} find condition
+                  {findConditionCount !== 1 ? 's' : ''} and
                   {supportsSetConditions
                     ? ` ${setConditions.length} set value${setConditions.length !== 1 ? 's' : ''}`
                     : ' no set values'}{' '}

--- a/src/components/database/queries/editor/query-information.tsx
+++ b/src/components/database/queries/editor/query-information.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import * as React from 'react';
+import { Check, ChevronDown, Search } from 'lucide-react';
+import { useFormContext } from 'react-hook-form';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { InputField } from '@/components/ui/form-inputs/InputField';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Switch } from '@/components/ui/switch';
+import { TextAreaField } from '@/components/ui/form-inputs/TextAreaField';
+import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
+import {
+  getOperationMeta,
+  getOperationBadgeVariant,
+} from '@/components/database/queries/query-operations';
+import { DeclaredSchema } from '@/lib/models/database';
+import { OperationsEnum } from '@/lib/models/database/custom-endpoints';
+import { cn } from '@/lib/utils';
+import { operationTypes } from './constants';
+
+const FIELD_LABEL = 'pl-0 text-sm font-medium text-foreground';
+
+interface QueryInformationProps {
+  contractLocked: boolean;
+  modelsLoading: boolean;
+  filteredModels: DeclaredSchema[];
+  modelSearchTerm: string;
+  onModelSearchChange: (value: string) => void;
+}
+
+export function QueryInformation({
+  contractLocked,
+  modelsLoading,
+  filteredModels,
+  modelSearchTerm,
+  onModelSearchChange,
+}: QueryInformationProps) {
+  const form = useFormContext();
+  const operation = Number(form.watch('operation')) as OperationsEnum;
+  const operationMeta = getOperationMeta(operation);
+  const selectedSchema = form.watch('selectedSchema') as string | undefined;
+  const selectedSchemaName = form.watch('selectedSchemaName') as
+    | string
+    | undefined;
+  const isFind = operation === OperationsEnum.GET;
+  const [isModelDialogOpen, setIsModelDialogOpen] = React.useState(false);
+
+  const applyOperation = (next: OperationsEnum) => {
+    if (contractLocked || next === operation) return;
+    form.setValue('operation', next, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Query Information</CardTitle>
+        <CardDescription>
+          Name, model, and runtime options for this endpoint
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="space-y-3">
+          <InputField
+            label="Query Name"
+            fieldName="name"
+            placeholder="GetUsersByTeam"
+            info="Becomes the Client API path: /database/function/{name}. Spaces are not allowed."
+            classNames={{
+              label: FIELD_LABEL,
+              input: 'font-mono slashed-zero',
+            }}
+          />
+
+          <TextAreaField
+            label="Description"
+            fieldName="endpointDescription"
+            placeholder="Describe what this query does"
+            rows={2}
+            classNames={{
+              label: FIELD_LABEL,
+            }}
+          />
+        </div>
+
+        <FormField
+          control={form.control}
+          name="operation"
+          render={() => (
+            <FormItem className="space-y-1.5">
+              <div className="flex items-center gap-1.5">
+                <FormLabel className="text-sm font-medium">Operation</FormLabel>
+                <QueryFieldHint
+                  content={
+                    contractLocked
+                      ? 'The HTTP method is part of the endpoint contract and cannot change after create.'
+                      : 'Maps to the HTTP method clients will call on /database/function/{name}.'
+                  }
+                />
+              </div>
+              <FormControl>
+                <div
+                  role="radiogroup"
+                  aria-label="Operation"
+                  aria-disabled={contractLocked || undefined}
+                  className="grid grid-cols-3 gap-1 rounded-lg bg-muted/40 p-1 sm:grid-cols-5"
+                  onKeyDown={event => {
+                    if (
+                      contractLocked ||
+                      (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft')
+                    ) {
+                      return;
+                    }
+                    event.preventDefault();
+                    const currentIndex = operationTypes.findIndex(
+                      op => op.value === operation
+                    );
+                    const delta = event.key === 'ArrowRight' ? 1 : -1;
+                    const next =
+                      operationTypes[
+                        (currentIndex + delta + operationTypes.length) %
+                          operationTypes.length
+                      ];
+                    applyOperation(next.value);
+                  }}
+                >
+                  {operationTypes.map(op => {
+                    const meta = getOperationMeta(op.value);
+                    const isSelected = operation === op.value;
+                    return (
+                      <button
+                        key={op.value}
+                        type="button"
+                        role="radio"
+                        aria-checked={isSelected}
+                        aria-disabled={contractLocked || undefined}
+                        disabled={contractLocked}
+                        tabIndex={isSelected ? 0 : -1}
+                        title={op.description}
+                        onClick={() => applyOperation(op.value)}
+                        className={cn(
+                          'flex h-12 min-w-0 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-md px-1 motion-reduce:transition-none transition-colors',
+                          isSelected
+                            ? 'bg-background text-foreground shadow-sm'
+                            : 'text-muted-foreground hover:text-foreground',
+                          contractLocked &&
+                            !isSelected &&
+                            'cursor-not-allowed opacity-40',
+                          contractLocked && isSelected && 'cursor-default',
+                          isSelected &&
+                            op.value === OperationsEnum.DELETE &&
+                            'text-destructive'
+                        )}
+                      >
+                        <span className="truncate text-xs font-medium">
+                          {op.label}
+                        </span>
+                        <span
+                          className={cn(
+                            'font-mono text-[10px] tabular-nums tracking-wide',
+                            isSelected
+                              ? 'text-foreground/70'
+                              : 'text-muted-foreground',
+                            isSelected &&
+                              op.value === OperationsEnum.DELETE &&
+                              'text-destructive/80'
+                          )}
+                        >
+                          {meta.method}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </FormControl>
+              <p className="text-xs text-muted-foreground">
+                {operationMeta.description}
+              </p>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm font-medium">Model</span>
+            <QueryFieldHint
+              content={
+                contractLocked
+                  ? 'The target schema is locked after create.'
+                  : 'The schema this endpoint reads or writes.'
+              }
+            />
+          </div>
+          <Dialog open={isModelDialogOpen} onOpenChange={setIsModelDialogOpen}>
+            <DialogTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={contractLocked}
+                aria-label={
+                  selectedSchemaName
+                    ? `Model: ${selectedSchemaName}`
+                    : 'Select a model'
+                }
+                className={cn(
+                  'h-9 w-full justify-between border-0 bg-muted/50 px-3 text-[13px] font-normal shadow-none',
+                  'hover:bg-muted focus-visible:bg-background focus-visible:ring-1 focus-visible:ring-primary/50',
+                  !selectedSchemaName && 'text-muted-foreground'
+                )}
+              >
+                <span className="truncate">
+                  {selectedSchemaName || 'Select a model'}
+                </span>
+                <ChevronDown className="size-4 shrink-0 opacity-50" />
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>Select Model</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-3">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    placeholder="Search models…"
+                    value={modelSearchTerm}
+                    onChange={event => onModelSearchChange(event.target.value)}
+                    className="pl-9"
+                  />
+                </div>
+                <ScrollArea className="h-[300px]">
+                  <div className="flex flex-col gap-0.5 pr-3">
+                    {modelsLoading && (
+                      <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                        Loading models…
+                      </p>
+                    )}
+                    {!modelsLoading && filteredModels.length === 0 && (
+                      <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                        No models match this operation and search.
+                      </p>
+                    )}
+                    {filteredModels.map(model => {
+                      const isSelected = selectedSchema === model._id;
+                      return (
+                        <Button
+                          key={model._id}
+                          type="button"
+                          variant="ghost"
+                          className={cn(
+                            'h-9 w-full justify-between px-3 text-left font-normal',
+                            isSelected && 'bg-accent'
+                          )}
+                          onClick={() => {
+                            form.setValue('selectedSchema', model._id, {
+                              shouldValidate: true,
+                              shouldDirty: true,
+                              shouldTouch: true,
+                            });
+                            form.setValue('selectedSchemaName', model.name, {
+                              shouldValidate: true,
+                              shouldDirty: true,
+                              shouldTouch: true,
+                            });
+                            setIsModelDialogOpen(false);
+                          }}
+                        >
+                          <span className="truncate">{model.name}</span>
+                          {isSelected && (
+                            <Check className="size-4 shrink-0 text-foreground" />
+                          )}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                </ScrollArea>
+              </div>
+            </DialogContent>
+          </Dialog>
+          {form.formState.errors.selectedSchema && (
+            <p className="text-sm text-destructive">
+              {String(form.formState.errors.selectedSchema.message)}
+            </p>
+          )}
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-border/60">
+          <div className="flex items-center justify-between gap-3 border-b border-border/60 bg-muted/30 px-3 py-2">
+            <p className="text-xs font-medium tracking-wide text-muted-foreground">
+              Runtime
+            </p>
+            {isFind && (
+              <Badge
+                variant={getOperationBadgeVariant(operation)}
+                className="font-mono font-normal tabular-nums"
+              >
+                {operationMeta.method}
+              </Badge>
+            )}
+          </div>
+          <div className="divide-y divide-border/60">
+            <RuntimeOption
+              name="authentication"
+              id="query-authentication"
+              label="Authentication"
+              description="Require a user bearer token"
+              hint="When enabled, callers must send a user bearer token. Anonymous Client API requests are rejected."
+            />
+            {isFind && (
+              <>
+                <RuntimeOption
+                  name="paginated"
+                  id="query-paginated"
+                  label="Pagination"
+                  description="Expose skip, limit, and a document count"
+                  hint="Adds skip and limit query parameters and returns a document count with results."
+                />
+                <RuntimeOption
+                  name="sorted"
+                  id="query-sorted"
+                  label="Sorting"
+                  description="Allow clients to pass sort parameters"
+                  hint="Allows clients to pass sort query parameters on GET requests."
+                />
+              </>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RuntimeOption({
+  name,
+  id,
+  label,
+  description,
+  hint,
+}: {
+  name: 'authentication' | 'paginated' | 'sorted';
+  id: string;
+  label: string;
+  description: string;
+  hint: string;
+}) {
+  const form = useFormContext();
+
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="flex items-center justify-between gap-4 px-3 py-3">
+          <div className="min-w-0 space-y-1">
+            <div className="flex items-center gap-1.5">
+              <FormLabel htmlFor={id} className="text-sm font-medium">
+                {label}
+              </FormLabel>
+              <QueryFieldHint content={hint} />
+            </div>
+            <FormDescription className="text-xs">{description}</FormDescription>
+          </div>
+          <FormControl>
+            <Switch
+              id={id}
+              checked={Boolean(field.value)}
+              onCheckedChange={field.onChange}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/src/components/database/queries/editor/query-input-item.tsx
+++ b/src/components/database/queries/editor/query-input-item.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import * as React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { ChevronDown, Trash2 } from 'lucide-react';
+import {
+  LocationEnum,
+  OperationsEnum,
+  ValueTypeEnum,
+} from '@/lib/models/database/custom-endpoints';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { InputField } from '@/components/ui/form-inputs/InputField';
+import SelectField from '@/components/ui/form-inputs/SelectField';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
+import { inputTypes, placementTypes } from './constants';
+import {
+  getPlacementExample,
+  getPlacementIcon,
+  getPlacementName,
+  toLocation,
+} from './utils';
+import { cn } from '@/lib/utils';
+
+interface QueryInputItemProps {
+  index: number;
+  operation: OperationsEnum;
+  onRemove: () => void;
+}
+
+const BODY_DISALLOWED_OPERATIONS = [OperationsEnum.GET, OperationsEnum.DELETE];
+
+export function QueryInputItem({
+  index,
+  operation,
+  onRemove,
+}: QueryInputItemProps) {
+  const form = useFormContext();
+  const name = (form.watch(`inputs.${index}.name`) as string) ?? '';
+  const type = form.watch(`inputs.${index}.type`) as ValueTypeEnum;
+  const location = toLocation(form.watch(`inputs.${index}.location`));
+  const optional = Boolean(form.watch(`inputs.${index}.optional`));
+  const isArray = Boolean(form.watch(`inputs.${index}.array`));
+  const [open, setOpen] = React.useState(!name);
+  const isPath = location === LocationEnum.URL;
+  const bodyAllowed = !BODY_DISALLOWED_OPERATIONS.includes(operation);
+
+  const applyLocation = (next: LocationEnum) => {
+    form.setValue(`inputs.${index}.location`, next, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+    if (next === LocationEnum.URL) {
+      form.setValue(`inputs.${index}.optional`, false, { shouldDirty: true });
+      form.setValue(`inputs.${index}.array`, false, { shouldDirty: true });
+    }
+  };
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="overflow-hidden rounded-lg border border-border/60 bg-card"
+    >
+      <div className="flex items-center gap-1 bg-muted/40 pr-1">
+        <CollapsibleTrigger className="flex min-h-10 min-w-0 flex-1 cursor-pointer items-center gap-2 px-3 py-2 text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring">
+          <ChevronDown
+            className={cn(
+              'size-4 shrink-0 text-muted-foreground motion-reduce:transition-none transition-transform',
+              open && 'rotate-180'
+            )}
+          />
+          <span className="min-w-0 truncate font-mono text-sm font-medium slashed-zero">
+            {name || `Input #${index + 1}`}
+          </span>
+          {!open && name && (
+            <span className="ml-auto flex min-w-0 items-center gap-1.5">
+              <Badge
+                variant="outline"
+                className="max-w-24 truncate font-normal tabular-nums"
+              >
+                {type}
+                {isArray ? '[]' : ''}
+              </Badge>
+              <Badge variant="secondary" className="font-normal">
+                {getPlacementName(location)}
+              </Badge>
+              {optional && (
+                <Badge variant="outline" className="font-normal">
+                  Optional
+                </Badge>
+              )}
+            </span>
+          )}
+        </CollapsibleTrigger>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove input ${name || index + 1}`}
+                onClick={onRemove}
+              >
+                <Trash2 className="size-4 text-destructive" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Remove this input from the draft. Save to persist.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+
+      <CollapsibleContent>
+        <div className="space-y-4 border-t border-border/60 p-4">
+          <InputField
+            label="Name"
+            fieldName={`inputs.${index}.name`}
+            placeholder="e.g. id, name, filter"
+            classNames={{
+              label: 'pl-0 text-sm font-medium text-foreground',
+              input: 'font-mono text-sm slashed-zero',
+            }}
+          />
+
+          <SelectField
+            label="Type"
+            fieldName={`inputs.${index}.type`}
+            placeholder="Select type"
+            classNames={{
+              selectTrigger:
+                'h-9 [&>span]:line-clamp-1 [&>span]:flex [&>span]:items-center',
+            }}
+            options={inputTypes.map(inputType => ({
+              value: inputType.value,
+              label: inputType.label,
+            }))}
+          />
+
+          <FormField
+            control={form.control}
+            name={`inputs.${index}.location`}
+            render={({ field }) => {
+              const selected = toLocation(field.value);
+              const enabledPlacements = placementTypes.filter(
+                place => place.value !== LocationEnum.BODY || bodyAllowed
+              );
+
+              return (
+                <FormItem className="space-y-1.5">
+                  <FormLabel>Placement</FormLabel>
+                  <FormControl>
+                    <div
+                      role="radiogroup"
+                      aria-label="Parameter placement"
+                      className="grid grid-cols-3 gap-1 rounded-lg border border-input bg-muted/40 p-1"
+                      onKeyDown={event => {
+                        if (
+                          event.key !== 'ArrowRight' &&
+                          event.key !== 'ArrowLeft'
+                        ) {
+                          return;
+                        }
+                        event.preventDefault();
+                        const currentIndex = enabledPlacements.findIndex(
+                          place => place.value === selected
+                        );
+                        const delta = event.key === 'ArrowRight' ? 1 : -1;
+                        const next =
+                          enabledPlacements[
+                            (currentIndex + delta + enabledPlacements.length) %
+                              enabledPlacements.length
+                          ];
+                        applyLocation(next.value);
+                      }}
+                    >
+                      {placementTypes.map(place => {
+                        const disabled =
+                          place.value === LocationEnum.BODY && !bodyAllowed;
+                        const isSelected = selected === place.value;
+                        return (
+                          <button
+                            key={place.value}
+                            type="button"
+                            role="radio"
+                            aria-checked={isSelected}
+                            aria-disabled={disabled || undefined}
+                            disabled={disabled}
+                            tabIndex={isSelected ? 0 : -1}
+                            title={
+                              disabled
+                                ? 'Body is not available for Find or Delete'
+                                : place.description
+                            }
+                            onClick={() => applyLocation(place.value)}
+                            className={cn(
+                              'flex h-8 min-w-0 cursor-pointer items-center justify-center gap-1.5 rounded-md px-1 text-xs font-medium motion-reduce:transition-none transition-colors',
+                              isSelected
+                                ? 'bg-background text-foreground shadow-sm'
+                                : 'text-muted-foreground hover:text-foreground',
+                              disabled && 'cursor-not-allowed opacity-40'
+                            )}
+                          >
+                            {getPlacementIcon(place.value, 'size-3.5 shrink-0')}
+                            <span className="truncate">
+                              {getPlacementName(place.value)}
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </FormControl>
+                  <p className="font-mono text-xs text-muted-foreground slashed-zero">
+                    {getPlacementExample(selected, name)}
+                  </p>
+                  {!bodyAllowed && selected === LocationEnum.BODY && (
+                    <p className="text-xs text-destructive">
+                      Body parameters are not allowed for Find/Delete operations
+                    </p>
+                  )}
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
+          />
+
+          <div className="flex flex-wrap gap-x-6 gap-y-3">
+            <FormField
+              control={form.control}
+              name={`inputs.${index}.optional`}
+              render={({ field }) => (
+                <FormItem className="flex min-h-8 flex-row items-center gap-2">
+                  <FormControl>
+                    <Checkbox
+                      id={`inputs.${index}.optional`}
+                      checked={Boolean(field.value)}
+                      disabled={isPath}
+                      onCheckedChange={checked =>
+                        field.onChange(Boolean(checked))
+                      }
+                    />
+                  </FormControl>
+                  <div className="flex items-center gap-1">
+                    <FormLabel
+                      htmlFor={`inputs.${index}.optional`}
+                      className="font-normal"
+                    >
+                      Optional
+                    </FormLabel>
+                    <QueryFieldHint content="Path parameters cannot be optional. Query and body inputs can be omitted by the client." />
+                  </div>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name={`inputs.${index}.array`}
+              render={({ field }) => (
+                <FormItem className="flex min-h-8 flex-row items-center gap-2">
+                  <FormControl>
+                    <Checkbox
+                      id={`inputs.${index}.array`}
+                      checked={Boolean(field.value)}
+                      disabled={isPath}
+                      onCheckedChange={checked =>
+                        field.onChange(Boolean(checked))
+                      }
+                    />
+                  </FormControl>
+                  <div className="flex items-center gap-1">
+                    <FormLabel
+                      htmlFor={`inputs.${index}.array`}
+                      className="font-normal"
+                    >
+                      Array
+                    </FormLabel>
+                    <QueryFieldHint content="Accept multiple values. Path parameters cannot be arrays." />
+                  </div>
+                </FormItem>
+              )}
+            />
+          </div>
+          {isPath && (
+            <p className="text-xs text-muted-foreground">
+              Path parameters are required URL segments, so they cannot be
+              optional or arrays.
+            </p>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/components/database/queries/editor/utils.tsx
+++ b/src/components/database/queries/editor/utils.tsx
@@ -1,6 +1,8 @@
 import {
+  AssignmentActionEnum,
   ComparisonOperationEnum,
   LocationEnum,
+  ValueSourceTypeEnum,
   ValueTypeEnum,
 } from '@/lib/models/database/custom-endpoints';
 import {
@@ -79,22 +81,25 @@ export const toLocation = (value: unknown): LocationEnum => {
   return LocationEnum.QUERY;
 };
 // Add icons for input types and placements
-export const getTypeIcon = (type: ValueTypeEnum) => {
+export const getTypeIcon = (
+  type: ValueTypeEnum,
+  className = 'size-3.5 shrink-0'
+) => {
   switch (type) {
     case ValueTypeEnum.STRING:
-      return <FormInput className="h-4 w-4" />;
+      return <FormInput className={className} />;
     case ValueTypeEnum.NUMBER:
-      return <Hash className="h-4 w-4" />;
+      return <Hash className={className} />;
     case ValueTypeEnum.BOOLEAN:
-      return <ToggleLeft className="h-4 w-4" />;
+      return <ToggleLeft className={className} />;
     case ValueTypeEnum.DATE:
-      return <Calendar className="h-4 w-4" />;
+      return <Calendar className={className} />;
     case ValueTypeEnum.JSON:
-      return <Braces className="h-4 w-4" />;
+      return <Braces className={className} />;
     case ValueTypeEnum.OBJECT_ID:
-      return <Key className="h-4 w-4" />;
+      return <Key className={className} />;
     default:
-      return <FormInput className="h-4 w-4" />;
+      return <FormInput className={className} />;
   }
 };
 
@@ -113,3 +118,83 @@ export const getReadableOperation = (op: ComparisonOperationEnum): string => {
   };
   return operationMap[op];
 };
+
+export function formatValueSource(
+  type: ValueSourceTypeEnum | undefined,
+  value: string | undefined
+): string {
+  const display = value?.trim();
+  switch (type) {
+    case ValueSourceTypeEnum.INPUT:
+      return display ? `input:${display}` : 'input:not selected';
+    case ValueSourceTypeEnum.CONTEXT:
+      return display ? `context:${display}` : 'context:not specified';
+    case ValueSourceTypeEnum.CUSTOM:
+      return display || 'empty';
+    default:
+      return display || '';
+  }
+}
+
+export function getConditionSummary({
+  schemaField,
+  operation,
+  sourceType,
+  value,
+  like,
+  caseSensitiveLike,
+  index,
+}: {
+  schemaField?: string;
+  operation: ComparisonOperationEnum;
+  sourceType?: ValueSourceTypeEnum;
+  value?: string;
+  like?: boolean;
+  caseSensitiveLike?: boolean;
+  index: number;
+}): string {
+  if (!schemaField) return `Condition #${index + 1}`;
+
+  let opPhrase = getReadableOperation(operation) || 'equals';
+  if (like && operation === ComparisonOperationEnum.EQUAL) {
+    opPhrase = caseSensitiveLike
+      ? 'matches (case-sensitive LIKE)'
+      : 'matches (LIKE)';
+  }
+
+  return `${schemaField} ${opPhrase} ${formatValueSource(sourceType, value)}`;
+}
+
+export function getAssignmentSummary({
+  schemaField,
+  action,
+  sourceType,
+  value,
+  index,
+}: {
+  schemaField?: string;
+  action: AssignmentActionEnum;
+  sourceType?: ValueSourceTypeEnum;
+  value?: string;
+  index: number;
+}): string {
+  if (!schemaField) return `Set #${index + 1}`;
+  const valueDisplay = formatValueSource(sourceType, value);
+
+  switch (action) {
+    case AssignmentActionEnum.ASSIGN:
+      return `${schemaField} = ${valueDisplay}`;
+    case AssignmentActionEnum.INC:
+      return `${schemaField} += ${valueDisplay}`;
+    case AssignmentActionEnum.DEC:
+      return `${schemaField} -= ${valueDisplay}`;
+    case AssignmentActionEnum.PUSH:
+      return `${schemaField} = ${schemaField}.concat(${valueDisplay})`;
+    case AssignmentActionEnum.PULL:
+      return `${schemaField} = ${schemaField}.remove(${valueDisplay})`;
+    default: {
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/components/database/queries/editor/utils.tsx
+++ b/src/components/database/queries/editor/utils.tsx
@@ -15,18 +15,24 @@ import {
   ToggleLeft,
 } from 'lucide-react';
 
-export const getPlacementIcon = (location: LocationEnum) => {
+export const getPlacementIcon = (
+  location: LocationEnum,
+  className = 'size-4'
+) => {
   switch (location) {
     case LocationEnum.URL:
-      return <Route className="h-4 w-4" />;
+      return <Route className={className} />;
     case LocationEnum.QUERY:
-      return <Search className="h-4 w-4" />;
+      return <Search className={className} />;
     case LocationEnum.BODY:
-      return <FileJson className="h-4 w-4" />;
-    default:
-      return <Search className="h-4 w-4" />;
+      return <FileJson className={className} />;
+    default: {
+      const _exhaustive: never = location;
+      return _exhaustive;
+    }
   }
 };
+
 export const getPlacementName = (location: LocationEnum) => {
   switch (location) {
     case LocationEnum.URL:
@@ -35,9 +41,42 @@ export const getPlacementName = (location: LocationEnum) => {
       return 'Search';
     case LocationEnum.BODY:
       return 'Body';
-    default:
-      return 'Search';
+    default: {
+      const _exhaustive: never = location;
+      return _exhaustive;
+    }
   }
+};
+
+export const getPlacementExample = (location: LocationEnum, name: string) => {
+  const key = name.trim() || 'key';
+  switch (location) {
+    case LocationEnum.URL:
+      return `Path segment /:${key}`;
+    case LocationEnum.QUERY:
+      return `URL query ?${key}=value`;
+    case LocationEnum.BODY:
+      return `JSON body { "${key}": … }`;
+    default: {
+      const _exhaustive: never = location;
+      return _exhaustive;
+    }
+  }
+};
+
+export const toLocation = (value: unknown): LocationEnum => {
+  if (value === '' || value === undefined || value === null) {
+    return LocationEnum.QUERY;
+  }
+  const location = Number(value);
+  if (
+    location === LocationEnum.URL ||
+    location === LocationEnum.QUERY ||
+    location === LocationEnum.BODY
+  ) {
+    return location;
+  }
+  return LocationEnum.QUERY;
 };
 // Add icons for input types and placements
 export const getTypeIcon = (type: ValueTypeEnum) => {

--- a/src/components/database/queries/empty-state.tsx
+++ b/src/components/database/queries/empty-state.tsx
@@ -1,13 +1,28 @@
+import type { ReactNode } from 'react';
 import { Database } from 'lucide-react';
 import { EmptyState } from '@/components/ui/empty-state';
+import { cn } from '@/lib/utils';
 
-export function QueryEmptyState() {
+interface QueryEmptyStateProps {
+  title?: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function QueryEmptyState({
+  title = 'No query selected',
+  description = 'Select a query from the list or create a new one.',
+  action,
+  className,
+}: QueryEmptyStateProps) {
   return (
     <EmptyState
       icon={Database}
-      title="No Query Selected"
-      description="Select a query from the list or create a new one"
-      className="h-full"
+      title={title}
+      description={description}
+      action={action}
+      className={cn('h-full', className)}
     />
   );
 }

--- a/src/components/database/queries/query-field-hint.tsx
+++ b/src/components/database/queries/query-field-hint.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Info } from 'lucide-react';
+import TooltipHelper from '@/components/ui/helpers/TooltipHelper';
+
+export function QueryFieldHint({ content }: { content: string }) {
+  return (
+    <TooltipHelper content={content}>
+      <span className="inline-flex size-4 items-center justify-center text-muted-foreground">
+        <Info className="size-3.5" aria-hidden />
+        <span className="sr-only">More information</span>
+      </span>
+    </TooltipHelper>
+  );
+}

--- a/src/components/database/queries/query-list/query-filters.tsx
+++ b/src/components/database/queries/query-list/query-filters.tsx
@@ -1,14 +1,18 @@
 'use client';
+
 import { Database, Search } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
 import { DeclaredSchema } from '@/lib/models/database';
+import { QueryFieldHint } from '@/components/database/queries/query-field-hint';
 
 interface QueryFiltersProps {
   searchTerm: string;
@@ -26,35 +30,54 @@ export function QueryFilters({
   models,
 }: Readonly<QueryFiltersProps>) {
   return (
-    <div className="shrink-0 space-y-4 border-b p-4">
-      <div className="flex items-center space-x-2">
-        <Search className="w-4 h-4 text-muted-foreground" />
-        <Input
-          placeholder="Search queries..."
-          value={searchTerm}
-          onChange={e => onSearchChange(e.target.value)}
-          className="h-9"
-        />
+    <div className="flex shrink-0 flex-col gap-3 border-b p-4">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="query-search" className="sr-only">
+          Search queries
+        </Label>
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            id="query-search"
+            placeholder="Search queries..."
+            value={searchTerm}
+            onChange={e => onSearchChange(e.target.value)}
+            className="h-9 pl-8"
+          />
+        </div>
       </div>
-      <Select
-        value={selectedModel ?? 'all'}
-        onValueChange={value => onModelChange(value)}
-      >
-        <SelectTrigger className="h-9">
-          <SelectValue placeholder="Filter by model" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All Models</SelectItem>
-          {models.map(model => (
-            <SelectItem key={model._id} value={model._id}>
-              <div className="flex items-center">
-                <Database className="w-4 h-4 mr-2" />
-                {model.name}
-              </div>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center gap-1">
+          <Label
+            htmlFor="query-model-filter"
+            className="text-xs text-muted-foreground"
+          >
+            Model
+          </Label>
+          <QueryFieldHint content="Show only endpoints that query a specific schema." />
+        </div>
+        <Select
+          value={selectedModel ?? 'all'}
+          onValueChange={value => onModelChange(value)}
+        >
+          <SelectTrigger id="query-model-filter" className="h-9">
+            <SelectValue placeholder="Filter by model" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="all">All models</SelectItem>
+              {models.map(model => (
+                <SelectItem key={model._id} value={model.name}>
+                  <div className="flex items-center">
+                    <Database className="mr-2 size-4" />
+                    {model.name}
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/src/components/database/queries/query-list/query-list-item.tsx
+++ b/src/components/database/queries/query-list/query-list-item.tsx
@@ -16,11 +16,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { CustomEndpoint } from '@/lib/models/database/custom-endpoints';
 import {
-  CustomEndpoint,
-  OperationsEnum,
-} from '@/lib/models/database/custom-endpoints';
-import { getOperationMeta } from '@/components/database/queries/query-operations';
+  getOperationBadgeVariant,
+  getOperationMeta,
+} from '@/components/database/queries/query-operations';
 import { cn } from '@/lib/utils';
 
 interface QueryListItemProps {
@@ -37,12 +37,7 @@ export function QueryListItem({
   onDelete,
 }: Readonly<QueryListItemProps>) {
   const meta = getOperationMeta(query.operation);
-  const badgeVariant =
-    query.operation === OperationsEnum.DELETE
-      ? 'destructive'
-      : query.operation === OperationsEnum.GET
-        ? 'secondary'
-        : 'outline';
+  const badgeVariant = getOperationBadgeVariant(query.operation);
 
   return (
     <div

--- a/src/components/database/queries/query-list/query-list-item.tsx
+++ b/src/components/database/queries/query-list/query-list-item.tsx
@@ -1,14 +1,33 @@
 'use client';
-import { Code, Search, Trash2 } from 'lucide-react';
+
+import { MoreHorizontal, Trash2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { CustomEndpoint } from '@/lib/models/database/custom-endpoints';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
+  CustomEndpoint,
+  OperationsEnum,
+} from '@/lib/models/database/custom-endpoints';
+import { getOperationMeta } from '@/components/database/queries/query-operations';
+import { cn } from '@/lib/utils';
 
 interface QueryListItemProps {
   query: CustomEndpoint;
   isSelected: boolean;
   onClick: () => void;
-  onDelete?: (id: string) => void;
+  onDelete?: (id: string, name: string) => void;
 }
 
 export function QueryListItem({
@@ -17,59 +36,74 @@ export function QueryListItem({
   onClick,
   onDelete,
 }: Readonly<QueryListItemProps>) {
-  const mapOperationToType = (operation: number) => {
-    switch (operation) {
-      case 0:
-        return 'Read';
-      case 1:
-        return 'Mutation';
-      case 2:
-        return 'Update';
-      case 3:
-        return 'Delete';
-      case 4:
-        return 'Patch';
-      default:
-        return 'Unknown';
-    }
-  };
+  const meta = getOperationMeta(query.operation);
+  const badgeVariant =
+    query.operation === OperationsEnum.DELETE
+      ? 'destructive'
+      : query.operation === OperationsEnum.GET
+        ? 'secondary'
+        : 'outline';
+
   return (
     <div
-      className={`group flex items-center gap-1 p-3 mb-2 rounded-md cursor-pointer ${isSelected ? 'bg-accent' : 'hover:bg-accent'}`}
-      onClick={onClick}
+      className={cn(
+        'group mb-2 flex items-center gap-1 rounded-md',
+        isSelected ? 'bg-accent' : 'hover:bg-accent/70'
+      )}
     >
-      {query.operation === 0 ? (
-        <Search className="w-4 h-4 shrink-0 text-blue-500" />
-      ) : (
-        <Code className="w-4 h-4 shrink-0 text-green-500" />
-      )}
-      <div className="flex-1 min-w-0">
-        <div className="font-medium truncate">{query.name}</div>
-        <div className="text-xs text-muted-foreground truncate">
-          {query.selectedSchemaName}
-        </div>
-      </div>
-      {onDelete && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-          aria-label={`Delete ${query.name}`}
-          onClick={e => {
-            e.stopPropagation();
-            onDelete(query._id);
-          }}
-        >
-          <Trash2 className="h-4 w-4 text-destructive" />
-        </Button>
-      )}
-      <Badge
-        variant={query.operation === 0 ? 'secondary' : 'outline'}
-        className="shrink-0"
+      <button
+        type="button"
+        onClick={onClick}
+        aria-current={isSelected ? 'page' : undefined}
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-md p-3 text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
       >
-        {mapOperationToType(query.operation)}
-      </Badge>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium">{query.name}</div>
+          <div className="truncate font-mono text-xs text-muted-foreground">
+            {meta.method} · {query.selectedSchemaName || 'No model'}
+          </div>
+        </div>
+        <Badge variant={badgeVariant} className="shrink-0 font-normal">
+          {meta.label}
+        </Badge>
+      </button>
+      {onDelete && (
+        <TooltipProvider delayDuration={300}>
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="mr-1 size-8 shrink-0"
+                    aria-label={`Actions for ${query.name}`}
+                    onClick={event => event.stopPropagation()}
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Query actions</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent
+              align="end"
+              onClick={event => event.stopPropagation()}
+            >
+              <DropdownMenuGroup>
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={() => onDelete(query._id, query.name)}
+                >
+                  <Trash2 className="mr-2 size-4" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </TooltipProvider>
+      )}
     </div>
   );
 }

--- a/src/components/database/queries/query-list/query-list.tsx
+++ b/src/components/database/queries/query-list/query-list.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Plus, Download, Loader2 } from 'lucide-react';
+import { Plus, Download, Loader2, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { QueryListItem } from './query-list-item';
 import { QueryListSkeleton } from './query-list-skeleton';
 import { QueryFilters } from './query-filters';
+import { QueryEmptyState } from '@/components/database/queries/empty-state';
 import { CustomEndpoint } from '@/lib/models/database/custom-endpoints';
 import { DeclaredSchema } from '@/lib/models/database';
 import React from 'react';
@@ -14,6 +15,9 @@ import {
   importCustomEndpoints,
 } from '@/lib/api/database';
 import { useToast } from '@/lib/hooks/use-toast';
+import { useQueryWorkspaceOptional } from '@/components/database/queries/query-workspace-context';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { cn } from '@/lib/utils';
 
 interface QueryListProps {
   queries: CustomEndpoint[];
@@ -22,11 +26,13 @@ interface QueryListProps {
   isLoading: boolean;
   searchTerm?: string;
   selectedModel?: string;
+  queriesError?: string | null;
   onSearchChange: (value: string) => void;
   onModelChange: (value: string) => void;
   onQuerySelect: (id: string) => void;
   onCreateQuery: () => void;
-  onDeleteQuery?: (id: string) => void;
+  onDeleteQuery?: (id: string, name: string) => void;
+  onRetry?: () => void;
   loadMoreRef: React.Ref<HTMLDivElement>;
   scrollRootRef: (node: HTMLDivElement | null) => void;
 }
@@ -38,20 +44,24 @@ export function QueryList({
   isLoading,
   searchTerm,
   selectedModel,
+  queriesError,
   onSearchChange,
   onModelChange,
   onQuerySelect,
   onCreateQuery,
   onDeleteQuery,
+  onRetry,
   loadMoreRef,
   scrollRootRef,
 }: Readonly<QueryListProps>) {
   const [exportImportDialog, setExportImportDialog] = React.useState(false);
   const listRef = React.useRef<HTMLDivElement | null>(null);
   const { toast } = useToast();
+  const workspace = useQueryWorkspaceOptional();
 
-  const isInitialLoading = isLoading && queries.length === 0;
+  const isInitialLoading = isLoading && queries.length === 0 && !queriesError;
   const isLoadingMore = isLoading && queries.length > 0;
+  const hasFilters = Boolean(searchTerm || selectedModel);
 
   const setListNode = React.useCallback(
     (node: HTMLDivElement | null) => {
@@ -80,40 +90,35 @@ export function QueryList({
         link.click();
         URL.revokeObjectURL(href);
         toast({
-          title: 'Export Successful',
-          description: 'Custom endpoints have been exported successfully.',
+          title: 'Export successful',
+          description: 'Custom endpoints have been exported.',
         });
       })
       .catch(error => {
         console.error(error);
         toast({
-          title: 'Export Failed',
+          title: 'Export failed',
           description: 'Failed to export custom endpoints.',
           variant: 'destructive',
         });
       });
   };
 
-  const handleImport = (imp: any) => {
-    importCustomEndpoints(imp)
-      .then(() => {
-        toast({
-          title: 'Import Successful',
-          description: 'Custom endpoints have been imported successfully.',
-        });
-      })
-      .catch(error => {
-        console.error(error);
-        toast({
-          title: 'Import Failed',
-          description: 'Failed to import custom endpoints.',
-          variant: 'destructive',
-        });
-      });
+  const handleImport = async (imp: unknown) => {
+    await importCustomEndpoints(imp);
+    toast({
+      title: 'Import successful',
+      description: 'Custom endpoints have been imported.',
+    });
+    await workspace?.refreshQueries();
   };
 
   return (
-    <div className="flex h-full min-h-0 w-64 shrink-0 flex-col overflow-hidden rounded-lg border shadow-xs">
+    <div
+      className={cn(
+        'flex h-full min-h-0 w-full shrink-0 flex-col overflow-hidden md:w-72 md:rounded-lg md:border md:shadow-xs'
+      )}
+    >
       <QueryFilters
         searchTerm={searchTerm ?? ''}
         onSearchChange={onSearchChange}
@@ -127,6 +132,26 @@ export function QueryList({
         className="min-h-0 flex-1 overflow-y-auto overscroll-contain main-scrollbar"
       >
         <div className="p-4">
+          {queriesError && (
+            <Alert variant="destructive" className="mb-3">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Could not load queries</AlertTitle>
+              <AlertDescription className="flex flex-col gap-2">
+                <p>{queriesError}</p>
+                {onRetry && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="w-fit"
+                    onClick={onRetry}
+                  >
+                    Retry
+                  </Button>
+                )}
+              </AlertDescription>
+            </Alert>
+          )}
           {isInitialLoading &&
             Array.from({ length: 3 }).map((_, i) => (
               <QueryListSkeleton key={`skeleton-${i}`} />
@@ -140,12 +165,26 @@ export function QueryList({
               onDelete={onDeleteQuery}
             />
           ))}
-          {!isInitialLoading && queries.length === 0 && (
-            <p className="px-1 py-6 text-center text-sm text-muted-foreground text-pretty">
-              {searchTerm || selectedModel
-                ? 'No queries match the current filters.'
-                : 'No custom queries yet.'}
-            </p>
+          {!isInitialLoading && !queriesError && queries.length === 0 && (
+            <QueryEmptyState
+              className="py-8"
+              title={
+                hasFilters ? 'No matching queries' : 'No custom queries yet'
+              }
+              description={
+                hasFilters
+                  ? 'Try a different search or model filter.'
+                  : 'Create an endpoint to expose a filtered query on the Client API.'
+              }
+              action={
+                !hasFilters ? (
+                  <Button type="button" size="sm" onClick={onCreateQuery}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    New query
+                  </Button>
+                ) : undefined
+              }
+            />
           )}
           <div
             ref={loadMoreRef}
@@ -158,10 +197,10 @@ export function QueryList({
         </div>
       </div>
 
-      <div className="mt-auto shrink-0 space-y-2 border-t p-4">
+      <div className="mt-auto flex shrink-0 flex-col gap-2 border-t p-4">
         <Button className="w-full" onClick={onCreateQuery}>
           <Plus className="mr-2 h-4 w-4" />
-          New Query
+          New query
         </Button>
         <Button
           variant="outline"
@@ -170,7 +209,7 @@ export function QueryList({
           onClick={() => setExportImportDialog(true)}
         >
           <Download className="mr-1 h-4 w-4" />
-          Export/Import
+          Export / Import
         </Button>
       </div>
 
@@ -180,7 +219,8 @@ export function QueryList({
         onOpenChange={setExportImportDialog}
         onExport={handleExport}
         onImport={handleImport}
-        importInfo="WARNING: Custom Endpoints with the same name will be overridden"
+        confirmImport
+        importInfo="Custom endpoints with the same name will be overwritten."
       />
     </div>
   );

--- a/src/components/database/queries/query-operations.ts
+++ b/src/components/database/queries/query-operations.ts
@@ -41,6 +41,23 @@ export function getOperationMeta(operation: number) {
   );
 }
 
+export function getOperationBadgeVariant(
+  operation: number
+): 'secondary' | 'destructive' | 'outline' {
+  switch (operation) {
+    case OperationsEnum.GET:
+      return 'secondary';
+    case OperationsEnum.DELETE:
+      return 'destructive';
+    case OperationsEnum.POST:
+    case OperationsEnum.PUT:
+    case OperationsEnum.PATCH:
+      return 'outline';
+    default:
+      return 'outline';
+  }
+}
+
 export function getEndpointPath(name?: string) {
   const slug = name?.trim() || '{name}';
   return `/database/function/${slug}`;

--- a/src/components/database/queries/query-operations.ts
+++ b/src/components/database/queries/query-operations.ts
@@ -1,0 +1,47 @@
+import { OperationsEnum } from '@/lib/models/database/custom-endpoints';
+
+export const OPERATION_META: Record<
+  OperationsEnum,
+  { label: string; method: string; description: string }
+> = {
+  [OperationsEnum.GET]: {
+    label: 'Find',
+    method: 'GET',
+    description: 'Retrieve documents that match the find conditions.',
+  },
+  [OperationsEnum.POST]: {
+    label: 'Create',
+    method: 'POST',
+    description: 'Insert a new document using the set values.',
+  },
+  [OperationsEnum.PUT]: {
+    label: 'Update',
+    method: 'PUT',
+    description: 'Replace matching documents with the set values.',
+  },
+  [OperationsEnum.PATCH]: {
+    label: 'Patch',
+    method: 'PATCH',
+    description: 'Partially update matching documents with the set values.',
+  },
+  [OperationsEnum.DELETE]: {
+    label: 'Delete',
+    method: 'DELETE',
+    description: 'Remove documents that match the find conditions.',
+  },
+};
+
+export function getOperationMeta(operation: number) {
+  return (
+    OPERATION_META[operation as OperationsEnum] ?? {
+      label: 'Unknown',
+      method: 'GET',
+      description: '',
+    }
+  );
+}
+
+export function getEndpointPath(name?: string) {
+  const slug = name?.trim() || '{name}';
+  return `/database/function/${slug}`;
+}

--- a/src/components/database/queries/query-workspace-context.tsx
+++ b/src/components/database/queries/query-workspace-context.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import * as React from 'react';
+
+export type PendingNavigation = () => void;
+
+export interface QueryWorkspaceContextValue {
+  selectedQueryId?: string;
+  isDirty: boolean;
+  setDirty: (dirty: boolean) => void;
+  requestNavigation: (navigate: PendingNavigation) => void;
+  refreshQueries: () => Promise<void>;
+  requestDelete: (id: string, name: string) => void;
+  closeListSheet: () => void;
+}
+
+const QueryWorkspaceContext =
+  React.createContext<QueryWorkspaceContextValue | null>(null);
+
+export function QueryWorkspaceProvider({
+  value,
+  children,
+}: {
+  value: QueryWorkspaceContextValue;
+  children: React.ReactNode;
+}) {
+  return (
+    <QueryWorkspaceContext.Provider value={value}>
+      {children}
+    </QueryWorkspaceContext.Provider>
+  );
+}
+
+export function useQueryWorkspace() {
+  const ctx = React.useContext(QueryWorkspaceContext);
+  if (!ctx) {
+    throw new Error(
+      'useQueryWorkspace must be used within QueryWorkspaceProvider'
+    );
+  }
+  return ctx;
+}
+
+export function useQueryWorkspaceOptional() {
+  return React.useContext(QueryWorkspaceContext);
+}

--- a/src/components/ui/export-import-dialog.tsx
+++ b/src/components/ui/export-import-dialog.tsx
@@ -2,6 +2,7 @@ import React, {
   ChangeEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -14,7 +15,16 @@ import {
   DialogFooter,
   DialogDescription,
 } from '@/components/ui/dialog';
-import { Separator } from '@/components/ui/separator';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import {
   Card,
   CardContent,
@@ -22,16 +32,40 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { Download, Upload, X, FileText, AlertTriangle } from 'lucide-react';
+import {
+  Download,
+  Upload,
+  FileText,
+  AlertTriangle,
+  Loader2,
+} from 'lucide-react';
 
 interface ExportImportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title?: string;
-  onImport?: (json: any) => void;
+  onImport?: (json: unknown) => void | Promise<void>;
   importInfo?: string;
   onExport?: () => void;
   exportInfo?: string;
+  confirmImport?: boolean;
+}
+
+function countImportedItems(payload: unknown) {
+  if (Array.isArray(payload)) return payload.length;
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    if (Array.isArray(record.customEndpoints)) {
+      return record.customEndpoints.length;
+    }
+    if (Array.isArray(record.endpoints)) {
+      return record.endpoints.length;
+    }
+    if (Array.isArray(record.schemas)) {
+      return record.schemas.length;
+    }
+  }
+  return 1;
 }
 
 const ExportImportDialog: React.FC<ExportImportDialogProps> = ({
@@ -42,32 +76,50 @@ const ExportImportDialog: React.FC<ExportImportDialogProps> = ({
   importInfo,
   onExport,
   exportInfo,
+  confirmImport = false,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string>();
+  const [pendingImport, setPendingImport] = useState<unknown | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
 
   useEffect(() => {
-    if (!open) setError(undefined);
+    if (!open) {
+      setError(undefined);
+      setPendingImport(null);
+      setIsImporting(false);
+    }
   }, [open]);
 
-  const generateTitle = (title?: string) => {
-    return `Export / Import${title ? ` - ${title}` : ''}`;
+  const generateTitle = (dialogTitle?: string) => {
+    return `Export / Import${dialogTitle ? ` - ${dialogTitle}` : ''}`;
   };
+
+  const pendingCount = useMemo(
+    () => (pendingImport == null ? 0 : countImportedItems(pendingImport)),
+    [pendingImport]
+  );
 
   const handleFileChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      if (!e.target?.files?.[0]) return;
-      new Response(e.target.files[0]).json().then(
+      const file = e.target?.files?.[0];
+      e.target.value = '';
+      if (!file) return;
+      new Response(file).json().then(
         json => {
           setError(undefined);
-          onImport?.(json);
+          if (confirmImport) {
+            setPendingImport(json);
+            return;
+          }
+          void onImport?.(json);
         },
         () => {
-          setError('Could not parse json file for import');
+          setError('Could not parse JSON file for import');
         }
       );
     },
-    [onImport]
+    [confirmImport, onImport]
   );
 
   const handleUploadClick = () => {
@@ -78,114 +130,172 @@ const ExportImportDialog: React.FC<ExportImportDialogProps> = ({
     onOpenChange(false);
   };
 
+  const handleConfirmImport = async () => {
+    if (pendingImport == null) return;
+    setIsImporting(true);
+    try {
+      await onImport?.(pendingImport);
+      setPendingImport(null);
+      onOpenChange(false);
+    } catch (importError) {
+      setError(
+        importError instanceof Error
+          ? importError.message
+          : 'Failed to import file'
+      );
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <FileText className="h-5 w-5" />
-            {generateTitle(title)}
-          </DialogTitle>
-          <DialogDescription>
-            Export your data to a JSON file or import data from a previously
-            exported file.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-4xl">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <FileText className="h-5 w-5" />
+              {generateTitle(title)}
+            </DialogTitle>
+            <DialogDescription>
+              Export your data to a JSON file or import data from a previously
+              exported file.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {onExport && (
-            <Card className="border-2 border-dashed border-muted-foreground/20 hover:border-muted-foreground/40 transition-all duration-200 hover:shadow-md">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-2 text-lg">
-                  <Download className="h-5 w-5 text-primary" />
-                  Export Data
-                </CardTitle>
-                <CardDescription>
-                  Download a JSON file containing all {title?.toLowerCase()}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {exportInfo && (
-                  <div className="flex items-start gap-2 p-3 bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg">
-                    <FileText className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
-                    <p className="text-sm text-blue-700 dark:text-blue-300">
-                      {exportInfo}
-                    </p>
-                  </div>
-                )}
-                <Button
-                  onClick={onExport}
-                  variant="default"
-                  className="w-full group"
-                  size="lg"
-                >
-                  <Download className="h-4 w-4 mr-2 group-hover:animate-bounce" />
-                  Export {title}
-                </Button>
-              </CardContent>
-            </Card>
-          )}
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {onExport && (
+              <Card className="border-2 border-dashed border-muted-foreground/20 transition-shadow hover:border-muted-foreground/40 hover:shadow-md">
+                <CardHeader className="pb-3">
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    <Download className="h-5 w-5 text-primary" />
+                    Export Data
+                  </CardTitle>
+                  <CardDescription>
+                    Download a JSON file containing all {title?.toLowerCase()}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  {exportInfo && (
+                    <div className="flex items-start gap-2 rounded-lg border border-border bg-muted/40 p-3">
+                      <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                      <p className="text-sm text-muted-foreground">
+                        {exportInfo}
+                      </p>
+                    </div>
+                  )}
+                  <Button
+                    onClick={onExport}
+                    variant="default"
+                    className="w-full"
+                    size="lg"
+                  >
+                    <Download className="mr-2 h-4 w-4" />
+                    Export {title}
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
 
-          {onImport && (
-            <Card className="border-2 border-dashed border-muted-foreground/20 hover:border-muted-foreground/40 transition-all duration-200 hover:shadow-md">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-2 text-lg">
-                  <Upload className="h-5 w-5 text-primary" />
-                  Import Data
-                </CardTitle>
-                <CardDescription>
-                  Upload a JSON file to import {title?.toLowerCase()}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {importInfo && (
-                  <div className="flex items-start gap-2 p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg">
-                    <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
-                    <p className="text-sm text-amber-700 dark:text-amber-300 font-medium">
-                      {importInfo}
-                    </p>
-                  </div>
-                )}
-                <Button
-                  onClick={handleUploadClick}
-                  variant="outline"
-                  className="w-full group"
-                  size="lg"
-                >
-                  <Upload className="h-4 w-4 mr-2 group-hover:animate-pulse" />
-                  Choose File
-                </Button>
-                <input
-                  type="file"
-                  ref={inputRef}
-                  onChange={handleFileChange}
-                  accept="application/JSON"
-                  className="hidden"
-                />
-              </CardContent>
-            </Card>
-          )}
-        </div>
-
-        <DialogFooter className="flex-col sm:flex-row gap-2">
-          {error && (
-            <div className="flex items-center gap-2 p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-sm text-destructive w-full sm:w-auto">
-              <AlertTriangle className="h-4 w-4 shrink-0" />
-              <span>{error}</span>
-            </div>
-          )}
-          <div className="flex gap-2 w-full sm:w-auto">
-            <Button
-              onClick={handleClose}
-              variant="outline"
-              className="flex-1 sm:flex-none"
-            >
-              Cancel
-            </Button>
+            {onImport && (
+              <Card className="border-2 border-dashed border-muted-foreground/20 transition-shadow hover:border-muted-foreground/40 hover:shadow-md">
+                <CardHeader className="pb-3">
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    <Upload className="h-5 w-5 text-primary" />
+                    Import Data
+                  </CardTitle>
+                  <CardDescription>
+                    Upload a JSON file to import {title?.toLowerCase()}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  {importInfo && (
+                    <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                      <p className="text-sm font-medium text-destructive">
+                        {importInfo}
+                      </p>
+                    </div>
+                  )}
+                  <Button
+                    onClick={handleUploadClick}
+                    variant="outline"
+                    className="w-full"
+                    size="lg"
+                  >
+                    <Upload className="mr-2 h-4 w-4" />
+                    Choose File
+                  </Button>
+                  <input
+                    type="file"
+                    ref={inputRef}
+                    onChange={handleFileChange}
+                    accept="application/json,.json"
+                    className="hidden"
+                  />
+                </CardContent>
+              </Card>
+            )}
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+
+          <DialogFooter className="flex-col gap-2 sm:flex-row">
+            {error && (
+              <div className="flex w-full items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive sm:w-auto">
+                <AlertTriangle className="h-4 w-4 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+            <div className="flex w-full gap-2 sm:w-auto">
+              <Button
+                onClick={handleClose}
+                variant="outline"
+                className="flex-1 sm:flex-none"
+              >
+                Cancel
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={pendingImport != null}
+        onOpenChange={openConfirm => {
+          if (!openConfirm && !isImporting) setPendingImport(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Import {title?.toLowerCase()}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will import {pendingCount}{' '}
+              {pendingCount === 1 ? 'item' : 'items'}
+              {importInfo ? `. ${importInfo}` : '.'} Continue only if you
+              reviewed the file.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isImporting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isImporting}
+              onClick={event => {
+                event.preventDefault();
+                void handleConfirmImport();
+              }}
+            >
+              {isImporting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Importing…
+                </>
+              ) : (
+                'Import'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 };
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -51,8 +51,7 @@ const SelectContent = React.forwardRef<
       <SelectPrimitive.Viewport
         className={cn(
           'p-1',
-          position === 'popper' &&
-            'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)'
+          position === 'popper' && 'w-full min-w-(--radix-select-trigger-width)'
         )}
       >
         {children}

--- a/src/lib/api/database/index.ts
+++ b/src/lib/api/database/index.ts
@@ -156,11 +156,11 @@ export const getCustomEndpoint = async (id: string) => {
 
 export const createCustomEndpoint = async (
   endpoint: Partial<CustomEndpoint>
-) => {
+): Promise<CustomEndpoint> => {
   return await (
     await getApiClient()
   )
-    .post(`/database/customEndpoints`, {
+    .post<CustomEndpoint>(`/database/customEndpoints`, {
       ...endpoint,
     })
     .then(res => res.data);
@@ -232,7 +232,7 @@ export const exportCustomEndpoints = async () => {
     .then(res => res.data);
 };
 
-export const importCustomEndpoints = async (data: any) => {
+export const importCustomEndpoints = async (data: unknown) => {
   return await (await getApiClient())
     .post('/database/customEndpoints/import', data)
     .then(res => res.data);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Custom Queries is the admin surface for Conduit custom endpoints (`GET/POST/PUT/PATCH/DELETE` → Client API `/database/function/{name}`). The page looked like a workspace but did not behave like one: list selection drifted from the URL, the model filter sent schema `_id` instead of `name`, create did not land on the new endpoint, unsaved edits could vanish on navigation, and delete/import had no consistent confirmation.

This change makes that workspace trustworthy for operators who already know the endpoint contract:

- URL drives list selection (`/new` vs `/:id`); after create, the editor redirects to the new id and the list refreshes
- Search is debounced; model filter uses `model.name` (`schemaName`); list fetch errors can be retried
- Delete (list and editor) names the endpoint and cannot be undone; import overwrite needs a second confirm; leaving dirty work asks to discard (Escape cancels)
- Keyboard-accessible list rows, always-visible actions, correct operation labels, empty/error/loading states, and a Queries sheet on narrow screens
- Sticky editor toolbar with name, unsaved badge, method, copyable path, Delete, and Save (`⌘S` / `Ctrl+S`), plus field hints

Export, Save, and Create stay unconfirmed. There is still no in-page request runner — that stays out of scope.

## Test plan

- [ ] Open `/database/queries`, select a query, confirm the URL matches the selected row
- [ ] Filter by model and search; results match the selected schema name, not `_id`
- [ ] Create a query, confirm redirect to `/database/queries/{id}` and that the list shows it
- [ ] Edit without saving, try to leave; discard dialog appears; Escape cancels
- [ ] Delete from the list and from the editor; confirmation names the endpoint
- [ ] Import queries JSON when endpoints already exist; overwrite confirm appears
- [ ] Copy the Client API path from the toolbar; Save with `⌘S` / `Ctrl+S`
- [ ] Narrow viewport: Queries sheet header does not overlap search
- [ ] Light and dark mode on list + editor
